### PR TITLE
Move example webpack config into examples/, add README

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,7 @@
+This directory contains some examples of code written with libram, as well as a Webpack configuration to build them.
+
+To build them, run the following command in the project root directory:
+
+```
+yarn run webpack -c examples/webpack.config.js
+```

--- a/examples/webpack.config.js
+++ b/examples/webpack.config.js
@@ -8,9 +8,9 @@ module.exports = {
   resolve: {
     extensions: ['.ts', '.tsx', '.js', '.json'],
   },
-  entry: fs.readdirSync('./examples/')
-    .filter(f => f.match(/.*\.(ts|js)$/))
-    .reduce((a, f) => ({ ...a, [f.split('.').slice(0, -1).join('.')]: path.join(__dirname, `examples/${f}`) }), {}),
+  entry: fs.readdirSync(__dirname)
+    .filter(f => f.match(/.*\.(ts|js)$/) && !/webpack.config.js/i.test(f))
+    .reduce((a, f) => ({ ...a, [f.split('.').slice(0, -1).join('.')]: path.join(__dirname, f) }), {}),
   output: {
     libraryTarget: 'commonjs',
     filename: 'libram-example-[name].js',
@@ -33,7 +33,7 @@ module.exports = {
     }),
     new ProvidePlugin({
       Buffer: ['buffer', 'Buffer'],
-      console: path.resolve(path.join(__dirname, 'src/console')),
+      console: path.resolve(path.join(__dirname, '../src/console')),
     }),
   ],
   externals: {


### PR DESCRIPTION
This PR moves the `webpack.config.js` into `examples/`, and adds `examples/README.md`.

## Why

The current webpack configuration is used to build the example code, not libram itself.

- If we're not going to use webpack to build libram, this file is going to confuse people simply by existing.
- If we're going to use webpack to build libram, then this file needs to be moved somewhere else, and we should put a proper build config in its place.

Either way, the example build config doesn't belong in the project root.