### PR TITLE
docs: Add CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,16 @@
+# How to contribute
+
+## Development Environment
+
+Libram is primarily developed on Linux. To develop libram on Windows, we recommend using WSL.
+
+libram uses Yarn classic. We intend to eventually move to Yarn v2, but there are no solid plans yet.
+
+You can use any editor for development. If you are uncertain, we recommend using Visual Studio Code.
+
+## Contributing Guidelines
+
+Before you submit a PR, please make sure to...
+
+- Run `yarn run format` to prettify your code
+- Run `yarn run lint` to check for gotchas in your code


### PR DESCRIPTION
Adds bare-bones Contribution Guidelines. We can expand it later as we see fit.

This does 90% of #13, except the "how to run tests" part, because we don't have tests yet.