### PR TITLE
Exclude source .ts files from being published

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,10 @@
     "prepare": "patch-package",
     "prepublishOnly": "yarn run build"
   },
-  "files": ["src/"],
+  "files": [
+    "src/**/*.js",
+    "src/**/*.d.ts"
+  ],
   "devDependencies": {
     "@babel/cli": "^7.12.1",
     "@babel/compat-data": "^7.12.7",


### PR DESCRIPTION
This is a follow-up to #10.

When I set up `yarn run build` to generate `.js` and `.d.ts` files, I forgot about updating `pkg.files`. Now, both the build artifacts (`.js` and `.d.ts`) and the TypeScript source files (`.ts`) are published.

Once libram is installed as a dependency, the TypeScript files don't do anything but take up disk space. I'm submitting a patch that excludes them from the publishing process.

Tested with `npm pack`, `npm publish --dry-run` and `yarn pack` to ensure that only the build artifacts are included when publishing. I also installed the generated tarball in a sample project to verify that the type definitions and code still work.