### PR TITLE
Fix circular imports

### DIFF
--- a/src/lib.ts
+++ b/src/lib.ts
@@ -26,8 +26,6 @@ import {
 
 import { $class } from "./template-string";
 import { get } from "./property";
-import { getRainDohBlackBoxCopiesMade } from "./resources/RainDoh";
-import { getSpookyPuttySheetCopiesMade } from "./resources/SpookyPutty";
 
 /**
  * Returns the current maximum Accordion Thief songs the player can have in their head
@@ -309,8 +307,4 @@ export function getFoldGroup(item: Item): Item[] {
 
 export function getZapGroup(item: Item): Item[] {
   return Object.keys(getRelated(item, "zap")).map((i) => Item.get(i));
-}
-
-export function getTotalPuttyLikeCopiesMade(): number {
-  return getSpookyPuttySheetCopiesMade() + getRainDohBlackBoxCopiesMade();
 }

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -25,8 +25,9 @@ import {
 } from "kolmafia";
 
 import { $class } from "./template-string";
-import { get } from ".";
-import { SpookyPutty, RainDoh } from "./resources";
+import { get } from "./property";
+import { getRainDohBlackBoxCopiesMade } from "./resources/RainDoh";
+import { getSpookyPuttySheetCopiesMade } from "./resources/SpookyPutty";
 
 /**
  * Returns the current maximum Accordion Thief songs the player can have in their head
@@ -311,8 +312,5 @@ export function getZapGroup(item: Item): Item[] {
 }
 
 export function getTotalPuttyLikeCopiesMade(): number {
-  return (
-    SpookyPutty.getSpookyPuttySheetCopiesMade() +
-    RainDoh.getRainDohBlackBoxCopiesMade()
-  );
+  return getSpookyPuttySheetCopiesMade() + getRainDohBlackBoxCopiesMade();
 }

--- a/src/resources/ObtuseAngel.ts
+++ b/src/resources/ObtuseAngel.ts
@@ -1,7 +1,8 @@
 import { haveFamiliar, useFamiliar } from "kolmafia";
-import { $familiar, get } from "../";
 import { Copier } from "../Copier";
 import { isCurrentFamiliar } from "../lib";
+import { get } from "../property";
+import { $familiar } from "../template-string";
 
 export const familiar = $familiar`Obtuse Angel`;
 

--- a/src/resources/RainDoh.ts
+++ b/src/resources/RainDoh.ts
@@ -1,13 +1,13 @@
 import { use } from "kolmafia";
 
+import { Copier } from "../Copier";
 import {
-  $item,
-  have as haveItem,
   getFoldGroup,
   getTotalPuttyLikeCopiesMade,
-  get,
-} from "..";
-import { Copier } from "../Copier";
+  have as haveItem,
+} from "../lib";
+import { get } from "../property";
+import { $item } from "../template-string";
 
 export const box = $item`Rain-Doh black box`;
 

--- a/src/resources/RainDoh.ts
+++ b/src/resources/RainDoh.ts
@@ -1,11 +1,6 @@
 import { use } from "kolmafia";
 
-import { Copier } from "../Copier";
-import {
-  getFoldGroup,
-  getTotalPuttyLikeCopiesMade,
-  have as haveItem,
-} from "../lib";
+import { getFoldGroup, have as haveItem } from "../lib";
 import { get } from "../property";
 import { $item } from "../template-string";
 
@@ -19,14 +14,6 @@ export function getRainDohBlackBoxCopiesMade(): number {
   return Math.max(0, get("_raindohCopiesMade"));
 }
 
-export function couldUseRainDohBlackBox(): boolean {
-  return (
-    have() &&
-    getRainDohBlackBoxCopiesMade() < 5 &&
-    getTotalPuttyLikeCopiesMade() < 6
-  );
-}
-
 export function getRainDohBlackBoxMonster(): Monster | null {
   return get("rainDohMonster");
 }
@@ -34,11 +21,3 @@ export function getRainDohBlackBoxMonster(): Monster | null {
 export function useRainDohBlackBox(): boolean {
   return use(box);
 }
-
-export const RainDohBlackBox = new Copier(
-  () => couldUseRainDohBlackBox(),
-  null,
-  () => couldUseRainDohBlackBox(),
-  () => getRainDohBlackBoxMonster(),
-  () => useRainDohBlackBox()
-);

--- a/src/resources/SourceTerminal.ts
+++ b/src/resources/SourceTerminal.ts
@@ -1,7 +1,9 @@
 import { cliExecute, toSkill } from "kolmafia";
 
-import { $effect, $item, $skill, haveInCampground, get } from "..";
 import { Copier } from "../Copier";
+import { haveInCampground } from "../lib";
+import { get } from "../property";
+import { $effect, $item, $skill } from "../template-string";
 
 export const item = $item`Source Terminal`;
 

--- a/src/resources/SpookyPutty.ts
+++ b/src/resources/SpookyPutty.ts
@@ -1,13 +1,13 @@
 import { cliExecute, use } from "kolmafia";
 
+import { Copier } from "../Copier";
 import {
-  $item,
-  have as haveItem,
   getFoldGroup,
   getTotalPuttyLikeCopiesMade,
-  get,
-} from "..";
-import { Copier } from "../Copier";
+  have as haveItem,
+} from "../lib";
+import { get } from "../property";
+import { $item } from "../template-string";
 
 export const sheet = $item`Spooky Putty sheet`;
 

--- a/src/resources/SpookyPutty.ts
+++ b/src/resources/SpookyPutty.ts
@@ -1,11 +1,6 @@
 import { cliExecute, use } from "kolmafia";
 
-import { Copier } from "../Copier";
-import {
-  getFoldGroup,
-  getTotalPuttyLikeCopiesMade,
-  have as haveItem,
-} from "../lib";
+import { getFoldGroup, have as haveItem } from "../lib";
 import { get } from "../property";
 import { $item } from "../template-string";
 
@@ -17,14 +12,6 @@ export function have(): boolean {
 
 export function getSpookyPuttySheetCopiesMade(): number {
   return Math.max(0, get("spookyPuttyCopiesMade"));
-}
-
-export function couldUseSpookyPuttySheet(): boolean {
-  return (
-    have() &&
-    getSpookyPuttySheetCopiesMade() < 5 &&
-    getTotalPuttyLikeCopiesMade() < 6
-  );
 }
 
 export function prepareSpookyPuttySheet(): boolean {
@@ -41,11 +28,3 @@ export function getSpookyPuttySheetMonster(): Monster | null {
 export function useSpookyPuttySheet(): boolean {
   return use(sheet);
 }
-
-export const SpookyPuttySheet = new Copier(
-  () => couldUseSpookyPuttySheet(),
-  () => prepareSpookyPuttySheet(),
-  () => couldUseSpookyPuttySheet(),
-  () => getSpookyPuttySheetMonster(),
-  () => useSpookyPuttySheet()
-);

--- a/src/resources/WinterGarden.ts
+++ b/src/resources/WinterGarden.ts
@@ -1,5 +1,7 @@
-import { $item, haveInCampground, have as haveItem, get } from "..";
 import { Copier } from "../Copier";
+import { get } from "../property";
+import { have as haveItem, haveInCampground } from "../lib";
+import { $item } from "../template-string";
 
 export function have(): boolean {
   return haveInCampground($item`packet of winter seeds`);

--- a/src/resources/Witchess.ts
+++ b/src/resources/Witchess.ts
@@ -1,4 +1,5 @@
-import { $item, haveInCampground } from "../";
+import { haveInCampground } from "../lib";
+import { $item } from "../template-string";
 
 export const item = $item`Witchess Set`;
 

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -4,3 +4,5 @@ export * as SourceTerminal from "./SourceTerminal";
 export * as SpookyPutty from "./SpookyPutty";
 export * as WinterGarden from "./WinterGarden";
 export * as Witchess from "./Witchess";
+
+export * from "./putty-likes";

--- a/src/resources/putty-likes.ts
+++ b/src/resources/putty-likes.ts
@@ -1,0 +1,50 @@
+import { Copier } from "../Copier";
+import {
+  getRainDohBlackBoxCopiesMade,
+  getRainDohBlackBoxMonster,
+  have as haveRainDoh,
+  useRainDohBlackBox,
+} from "./RainDoh";
+import {
+  getSpookyPuttySheetCopiesMade,
+  getSpookyPuttySheetMonster,
+  have as haveSpookyPutty,
+  prepareSpookyPuttySheet,
+  useSpookyPuttySheet,
+} from "./SpookyPutty";
+
+export function getTotalPuttyLikeCopiesMade(): number {
+  return getSpookyPuttySheetCopiesMade() + getRainDohBlackBoxCopiesMade();
+}
+
+export function couldUseRainDohBlackBox(): boolean {
+  return (
+    haveRainDoh() &&
+    getRainDohBlackBoxCopiesMade() < 5 &&
+    getTotalPuttyLikeCopiesMade() < 6
+  );
+}
+
+export const RainDohBlackBox = new Copier(
+  () => couldUseRainDohBlackBox(),
+  null,
+  () => couldUseRainDohBlackBox(),
+  () => getRainDohBlackBoxMonster(),
+  () => useRainDohBlackBox()
+);
+
+export function couldUseSpookyPuttySheet(): boolean {
+  return (
+    haveSpookyPutty() &&
+    getSpookyPuttySheetCopiesMade() < 5 &&
+    getTotalPuttyLikeCopiesMade() < 6
+  );
+}
+
+export const SpookyPuttySheet = new Copier(
+  () => couldUseSpookyPuttySheet(),
+  () => prepareSpookyPuttySheet(),
+  () => couldUseSpookyPuttySheet(),
+  () => getSpookyPuttySheetMonster(),
+  () => useSpookyPuttySheet()
+);


### PR DESCRIPTION
Fix circular imports. I used [madge](https://github.com/pahen/madge) to identify circular imports and manually removed them.

- Most issues are solved by simply importing from the module that defines the function.
- `SpookyPutty.ts` and `RainDoh.ts` had some functions that were referencing each other, so extract them to `putty-likes.ts` which serves as a coalescing module of sorts.

Incidentally, this did not solve the bundling issue where tree shaking fails and the entirety of `libram` and `node-html-parser` is included in the bundle. I suspect it has something to do with `node-html-parser` itself.

Edit: See #18 for enabling tree shaking.