### PR TITLE
feat: Set pkg.sideEffects to true

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,5 +54,6 @@
   },
   "lint-staged": {
     "src/**/*.{ts,js}": "prettier --write"
-  }
+  },
+  "sideEffects": false
 }


### PR DESCRIPTION
Set the `sideEffects` field in `package.json` to `true`. This allows downstream projects that use bundlers like Webpack to properly
tree-shake libram without having to dive deep into node_modules.

On the flip side, now we have to make extra sure that libram does not have side effects (e.g. modifying globals).

Tested by creating an example project that uses libram with the following bundlers:

- Webpack 5.11.1
- Rollup 2.36.0 + @rollup/plugin-node-resolve 11.0.1

## Example project code

```ts
// index.ts, compile with --skipLibCheck --module ES2015 --moduleResolution node
import { print } from "kolmafia";
import { $element } from "libram";

let a = $element`hot`;
print(`This element: ${a}`);
```

```js
// webpack.config.js
const {} = require("webpack");
const TerserPlugin = require("terser-webpack-plugin");
const path = require("path");
const fs = require("fs");

module.exports = {
  mode: "production",
  devtool: false,
  resolve: {
    extensions: [".ts", ".tsx", ".js", ".json"],
  },
  entry: "./index.js",
  output: {
    libraryTarget: "commonjs",
    filename: "index.js",
  },
  target: "node",
  module: {
    rules: [
      {
        // Include ts, tsx, js, and jsx files.
        test: /\.(ts|js)x?$/,
        // exclude: /node_modules(?!\/(libram|buffer))/,
        loader: "babel-loader",
      },
    ],
  },
  externals: {
    kolmafia: "commonjs kolmafia",
  },
};
```

```js
// rollup.config.js
import commonjs from "@rollup/plugin-commonjs";
import { nodeResolve } from "@rollup/plugin-node-resolve";

export default {
  context: "this",
  input: "index.js",
  output: {
    file: "dist/bundle.js",
    format: "cjs",
  },
  external: ["kolmafia"],
  plugins: [nodeResolve(), commonjs()],
};
```

