### PR TITLE
build: Minor fixes for locally generating docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Generate static docs
         run: |
           yarn
-          yarn run typedoc
+          yarn run docs
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist/
 .vscode/
 src/**/*.js
 src/**/*.d.ts
+/docs/

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "scripts": {
     "build": "yarn run tsc",
     "clean": "rm -f {src,dist}/*.js {src,dist}/*.d.ts {src,dist}/**/*.js {src,dist}/**/*.d.ts",
+    "docs": "yarn run typedoc",
     "format": "yarn run prettier --write src/**/* examples/**/*",
     "lint": "yarn run eslint src --ext .ts",
     "prepare": "patch-package",


### PR DESCRIPTION
- Run typedoc through `yarn run docs`. This enables us to generate docs locally with a click from VS Code & other IDEs.
    - Make the `docs.yml` GitHub workflow use `yarn run docs` instead of directly running typedoc.
- Add `/docs/` to `.gitignore`, so that we don't accidentally commit locally generated docs (which happened in #24, but was quickly corrected before it was merged).