### PR TITLE
Polyfill Object.values

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "webpack-cli": "^4.2.0"
   },
   "dependencies": {
+    "core-js": "3.9.0",
     "kolmafia": "^1.0.3",
     "node-html-parser": "^2.0.0"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+import "core-js/features/object/values";
+
 export * from "./Clan";
 export * from "./combat";
 export * from "./lib";

--- a/yarn.lock
+++ b/yarn.lock
@@ -1724,6 +1724,11 @@ core-js-compat@^3.6.2:
     browserslist "^4.14.6"
     semver "7.0.0"
 
+core-js@3.9.0:
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.9.0.tgz#790b1bb11553a2272b36e2625c7179db345492f8"
+  integrity sha512-PyFBJaLq93FlyYdsndE5VaueA9K5cNB7CGzeCj191YYLhkQM0gdZR2SKihM70oF0wdqKSKClv/tEBOpoRmdOVQ==
+
 core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"


### PR DESCRIPTION
Object.values isn't supplied by Rhino. I thought that babel would convert it but it seems you need to polyfill. Anyway so this should fix it without importing every single polyfill in the world.