### PR TITLE
Swapped Ode to Booze spell and effect names to correctly match game versions.

### DIFF
--- a/src/resources/2009/Bandersnatch.ts
+++ b/src/resources/2009/Bandersnatch.ts
@@ -63,8 +63,8 @@ export function couldRunaway(considerWeightAdjustment = true): boolean {
   return have() && getRemainingRunaways(considerWeightAdjustment) > 0;
 }
 
-const odeSkill = $skill`Ode to Booze`;
-const odeEffect = $effect`The Ode to Booze`;
+const odeSkill = $skill`The Ode to Booze`;
+const odeEffect = $effect`Ode to Booze`;
 
 /**
  * Returns true if the player can use their Bandersnatch to get a


### PR DESCRIPTION
Existing version results in:
> Internal exception: Wrapped net.sourceforge.kolmafia.textui.ScriptException: Bad effect value: The Ode to Booze