### PR TITLE
Switch lodash import format.

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   "dependencies": {
     "core-js": "3.15.2",
     "kolmafia": "^1.1.1",
-    "lodash-es": "^4.17.21"
+    "lodash": "^4.17.21"
   },
   "husky": {
     "hooks": {

--- a/src/resources/2016/SourceTerminal.ts
+++ b/src/resources/2016/SourceTerminal.ts
@@ -1,6 +1,6 @@
 import "core-js/features/object/values";
 import { cliExecute } from "kolmafia";
-import { isEqual } from "lodash-es";
+import isEqual from "lodash/isEqual";
 
 import { Copier } from "../../Copier";
 import { haveInCampground } from "../../lib";

--- a/yarn.lock
+++ b/yarn.lock
@@ -2930,15 +2930,15 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
-lodash-es@^4.17.21:
-  version "4.17.21"
-  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
-  integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
-
 lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
+
+lodash@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
 log-symbols@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
This reduces bundle sizes of importers of the library substantially.