### PR TITLE
Export the withX functions from property.ts.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,4 +9,12 @@ export * from "./template-string";
 export { default as logger, LogLevel } from "./logger";
 export * as console from "./console";
 export * as property from "./property";
-export { get, set } from "./property";
+export {
+  get,
+  set,
+  setProperties,
+  withProperties,
+  withProperty,
+  withChoices,
+  withChoice,
+} from "./property";


### PR DESCRIPTION
Awkward to do `property.withChoice` everywhere, clear without the namespace qualifier.