### PR TITLE
exclude meteor shower specifically from being listed as a skill name

### DIFF
--- a/src/combat.ts
+++ b/src/combat.ts
@@ -11,7 +11,7 @@ import {
   visitUrl,
   xpath,
 } from "kolmafia";
-import { $skills } from ".";
+import { $items, $skills } from ".";
 import { get, set } from "./property";
 
 const MACRO_NAME = "Script Autoattack Macro";
@@ -52,7 +52,11 @@ function itemOrItemsBallsMacroName(
     return itemOrItems.map(itemOrItemsBallsMacroName).join(", ");
   } else {
     const item = itemOrNameToItem(itemOrItems);
-    return item.name;
+    return !$items`spider web, really sticky spider web, dictionary, NG, Cloaca-Cola, yo-yo, top, ball, kite, yo, red potion, blue potion, adder, red button, pile of sand, mushroom, deluxe mushroom`.includes(
+      item
+    )
+      ? item.name
+      : toInt(item).toString();
   }
 }
 

--- a/src/combat.ts
+++ b/src/combat.ts
@@ -11,7 +11,7 @@ import {
   visitUrl,
   xpath,
 } from "kolmafia";
-import { $skill } from ".";
+import { $skills } from ".";
 import { get, set } from "./property";
 
 const MACRO_NAME = "Script Autoattack Macro";
@@ -77,7 +77,10 @@ function skillOrNameToSkill(skillOrName: SkillOrName) {
 
 function skillBallsMacroName(skillOrName: SkillOrName) {
   const skill = skillOrNameToSkill(skillOrName);
-  return skill.name.match(/^[A-Za-z ]+$/) && skill !== $skill`Meteor Shower`
+  return skill.name.match(/^[A-Za-z ]+$/) &&
+    !$skills`Shoot, Thrust-Smack, Headbutt, Toss, Sing, Disarm, LIGHT, BURN, Extract, Meteor Shower, Cleave, Boil, Slice, Rainbow`.includes(
+      skill
+    )
     ? skill.name
     : toInt(skill);
 }

--- a/src/combat.ts
+++ b/src/combat.ts
@@ -11,6 +11,7 @@ import {
   visitUrl,
   xpath,
 } from "kolmafia";
+import { $skill } from ".";
 import { get, set } from "./property";
 
 const MACRO_NAME = "Script Autoattack Macro";
@@ -76,7 +77,9 @@ function skillOrNameToSkill(skillOrName: SkillOrName) {
 
 function skillBallsMacroName(skillOrName: SkillOrName) {
   const skill = skillOrNameToSkill(skillOrName);
-  return skill.name.match(/^[A-Za-z ]+$/) ? skill.name : toInt(skill);
+  return skill.name.match(/^[A-Za-z ]+$/) && skill !== $skill`Meteor Shower`
+    ? skill.name
+    : toInt(skill);
 }
 
 type Constructor<T> = { new (): T };

--- a/src/combat.ts
+++ b/src/combat.ts
@@ -45,6 +45,9 @@ function itemOrNameToItem(itemOrName: ItemOrName) {
   return typeof itemOrName === "string" ? Item.get(itemOrName) : itemOrName;
 }
 
+const substringCombatItems = $items`spider web, really sticky spider web, dictionary, NG, Cloaca-Cola, yo-yo, top, ball, kite, yo, red potion, blue potion, adder, red button, pile of sand, mushroom, deluxe mushroom`;
+const substringCombatSkills = $skills`Shoot, Thrust-Smack, Headbutt, Toss, Sing, Disarm, LIGHT, BURN, Extract, Meteor Shower, Cleave, Boil, Slice, Rainbow`;
+
 function itemOrItemsBallsMacroName(
   itemOrItems: ItemOrName | [ItemOrName, ItemOrName]
 ): string {
@@ -52,9 +55,7 @@ function itemOrItemsBallsMacroName(
     return itemOrItems.map(itemOrItemsBallsMacroName).join(", ");
   } else {
     const item = itemOrNameToItem(itemOrItems);
-    return !$items`spider web, really sticky spider web, dictionary, NG, Cloaca-Cola, yo-yo, top, ball, kite, yo, red potion, blue potion, adder, red button, pile of sand, mushroom, deluxe mushroom`.includes(
-      item
-    )
+    return !substringCombatItems.includes(item)
       ? item.name
       : toInt(item).toString();
   }
@@ -82,9 +83,7 @@ function skillOrNameToSkill(skillOrName: SkillOrName) {
 function skillBallsMacroName(skillOrName: SkillOrName) {
   const skill = skillOrNameToSkill(skillOrName);
   return skill.name.match(/^[A-Za-z ]+$/) &&
-    !$skills`Shoot, Thrust-Smack, Headbutt, Toss, Sing, Disarm, LIGHT, BURN, Extract, Meteor Shower, Cleave, Boil, Slice, Rainbow`.includes(
-      skill
-    )
+    !substringCombatSkills.includes(skill)
     ? skill.name
     : toInt(skill);
 }

--- a/tools/findOverlappingNames.ts
+++ b/tools/findOverlappingNames.ts
@@ -1,0 +1,11 @@
+import { toItem, toLowerCase, toSkill } from "kolmafia";
+
+function overlappingSkills(): Skill[] {
+    const combatSkillNames = Skill.all().filter((skill) => skill.combat).map((skill) => toLowerCase(skill.name));
+    return combatSkillNames.filter((name1) => combatSkillNames.some((name2) => name2 !== name1 && name2.includes(name1))).map(toSkill)
+}
+
+function overlappingItems(): Item[] {
+    const combatItemNames = Item.all().filter((item) => item.combat).map((item) => toLowerCase(item.name));
+    return combatItemNames.filter((name1) => combatItemNames.some((name2) => name2 !== name1 && name2.includes(name1))).map(toItem)
+}

--- a/tools/findOverlappingNames.ts
+++ b/tools/findOverlappingNames.ts
@@ -1,11 +1,23 @@
-import { toItem, toLowerCase, toSkill } from "kolmafia";
+import { toItem, toSkill } from "kolmafia";
 
 function overlappingSkills(): Skill[] {
-    const combatSkillNames = Skill.all().filter((skill) => skill.combat).map((skill) => toLowerCase(skill.name));
-    return combatSkillNames.filter((name1) => combatSkillNames.some((name2) => name2 !== name1 && name2.includes(name1))).map(toSkill)
+  const combatSkillNames = Skill.all()
+    .filter((skill) => skill.combat)
+    .map((skill) => skill.name.toLowerCase());
+  return combatSkillNames
+    .filter((name1) =>
+      combatSkillNames.some((name2) => name2 !== name1 && name2.includes(name1))
+    )
+    .map(toSkill);
 }
 
 function overlappingItems(): Item[] {
-    const combatItemNames = Item.all().filter((item) => item.combat).map((item) => toLowerCase(item.name));
-    return combatItemNames.filter((name1) => combatItemNames.some((name2) => name2 !== name1 && name2.includes(name1))).map(toItem)
+  const combatItemNames = Item.all()
+    .filter((item) => item.combat)
+    .map((item) => item.name.toLowerCase());
+  return combatItemNames
+    .filter((name1) =>
+      combatItemNames.some((name2) => name2 !== name1 && name2.includes(name1))
+    )
+    .map(toItem);
 }


### PR DESCRIPTION
Ultimately this is a BALLS issue, but if "skill meteor shower" doesn't hit meteor shower, it hits volcanoMETEOR SHOWERruption, which is suboptimal. 

Alternately, we can switch to categoraically always using skill IDs.