### PR TITLE
Rewrite maximize cache to store equipment list and multiple entries

### DIFF
--- a/src/maximize.ts
+++ b/src/maximize.ts
@@ -170,7 +170,10 @@ function verifyCached(entry: CacheEntry): boolean {
     }
   }
 
-  if (equippedAmount($item`Crown of Thrones`) > 0) {
+  if (
+    equippedAmount($item`Crown of Thrones`) > 0 &&
+    entry.rider.get($item`Crown of Thrones`)
+  ) {
     if (entry.rider.get($item`Crown of Thrones`) !== myEnthronedFamiliar()) {
       logger.warning(
         `Failed to apply ${entry.rider.get(
@@ -181,7 +184,10 @@ function verifyCached(entry: CacheEntry): boolean {
     }
   }
 
-  if (equippedAmount($item`Buddy Bjorn`) > 0) {
+  if (
+    equippedAmount($item`Buddy Bjorn`) > 0 &&
+    entry.rider.get($item`Buddy Bjorn`)
+  ) {
     if (entry.rider.get($item`Buddy Bjorn`) !== myBjornedFamiliar()) {
       logger.warning(
         `Failed to apply${entry.rider.get(

--- a/src/maximize.ts
+++ b/src/maximize.ts
@@ -20,6 +20,7 @@ export type MaximizeOptions = {
   forceEquip?: Item[];
   preventEquip?: Item[];
   bonusEquip?: Map<Item, number>;
+  bonusCarry?: Map<Familiar, number>;
   onlySlot?: Slot[];
   preventSlot?: Slot[];
 };
@@ -30,6 +31,7 @@ const defaultMaximizeOptions = {
   forceEquip: [],
   preventEquip: [],
   bonusEquip: new Map(),
+  bonusCarry: new Map(),
   onlySlot: [],
   preventSlot: [],
 };
@@ -274,6 +276,7 @@ export function maximizeCached(
     forceEquip,
     preventEquip,
     bonusEquip,
+    bonusCarry,
     onlySlot,
     preventSlot,
   }: {
@@ -282,6 +285,7 @@ export function maximizeCached(
     forceEquip: Item[];
     preventEquip: Item[];
     bonusEquip: Map<Item, number>;
+    bonusCarry: Map<Familiar, number>;
     onlySlot: Slot[];
     preventSlot: Slot[];
   } = { ...defaultMaximizeOptions, ...options };
@@ -295,6 +299,12 @@ export function maximizeCached(
     ...preventSlot.map((slot) => `-${slot}`).sort(),
     ...Array.from(bonusEquip.entries())
       .map(([item, bonus]) => `${Math.round(bonus * 100) / 100} bonus ${item}`)
+      .sort(),
+    ...Array.from(bonusCarry.entries())
+      .map(
+        ([familiar, bonus]) =>
+          `${Math.round(bonus * 100) / 100} bonus-carry ${familiar}`
+      )
       .sort(),
   ].join(", ");
 

--- a/src/maximize.ts
+++ b/src/maximize.ts
@@ -320,6 +320,7 @@ export function maximizeCached(
     logger.info("Equipment found in maximize cache, equipping...");
     applyCached(cacheEntry);
     if (verifyCached(cacheEntry)) {
+      logger.info(`Equipped cached ${objective}`);
       return;
     }
     logger.warning("Maximize cache application failed, maximizing...");

--- a/src/maximize.ts
+++ b/src/maximize.ts
@@ -20,7 +20,6 @@ export type MaximizeOptions = {
   forceEquip?: Item[];
   preventEquip?: Item[];
   bonusEquip?: Map<Item, number>;
-  bonusCarry?: Map<Familiar, number>;
   onlySlot?: Slot[];
   preventSlot?: Slot[];
 };
@@ -31,7 +30,6 @@ const defaultMaximizeOptions = {
   forceEquip: [],
   preventEquip: [],
   bonusEquip: new Map(),
-  bonusCarry: new Map(),
   onlySlot: [],
   preventSlot: [],
 };
@@ -276,7 +274,6 @@ export function maximizeCached(
     forceEquip,
     preventEquip,
     bonusEquip,
-    bonusCarry,
     onlySlot,
     preventSlot,
   }: {
@@ -285,7 +282,6 @@ export function maximizeCached(
     forceEquip: Item[];
     preventEquip: Item[];
     bonusEquip: Map<Item, number>;
-    bonusCarry: Map<Familiar, number>;
     onlySlot: Slot[];
     preventSlot: Slot[];
   } = { ...defaultMaximizeOptions, ...options };
@@ -299,12 +295,6 @@ export function maximizeCached(
     ...preventSlot.map((slot) => `-${slot}`).sort(),
     ...Array.from(bonusEquip.entries())
       .map(([item, bonus]) => `${Math.round(bonus * 100) / 100} bonus ${item}`)
-      .sort(),
-    ...Array.from(bonusCarry.entries())
-      .map(
-        ([familiar, bonus]) =>
-          `${Math.round(bonus * 100) / 100} bonus-carry ${familiar}`
-      )
       .sort(),
   ].join(", ");
 

--- a/src/maximize.ts
+++ b/src/maximize.ts
@@ -298,8 +298,14 @@ export function maximizeCached(
     ...objectives.sort(),
     ...forceEquip.map((item) => `equip ${item}`).sort(),
     ...preventEquip.map((item) => `-equip ${item}`).sort(),
-    ...onlySlot.map((slot) => `${slot}`).sort(),
-    ...preventSlot.map((slot) => `-${slot}`).sort(),
+    ...onlySlot
+      .filter((slot) => !$slots`buddy-bjorn, crown-of-thrones`.includes(slot))
+      .map((slot) => `${slot}`)
+      .sort(),
+    ...preventSlot
+      .filter((slot) => !$slots`buddy-bjorn, crown-of-thrones`.includes(slot))
+      .map((slot) => `-${slot}`)
+      .sort(),
     ...Array.from(bonusEquip.entries())
       .map(([item, bonus]) => `${Math.round(bonus * 100) / 100} bonus ${item}`)
       .sort(),

--- a/src/maximize.ts
+++ b/src/maximize.ts
@@ -226,7 +226,7 @@ function saveCached(cacheKey: string, options: MaximizeOptions): void {
     rider.set($item`Buddy Bjorn`, myBjornedFamiliar());
   }
 
-  if (options.preventSlot) {
+  if (options.preventSlot && options.preventSlot.length > 0) {
     for (const slot of options.preventSlot) {
       equipment.delete(slot);
     }
@@ -238,7 +238,7 @@ function saveCached(cacheKey: string, options: MaximizeOptions): void {
     }
   }
 
-  if (options.onlySlot) {
+  if (options.onlySlot && options.onlySlot.length > 0) {
     for (const slot of Slot.all()) {
       if (!options.onlySlot.includes(slot)) {
         equipment.delete(slot);

--- a/src/maximize.ts
+++ b/src/maximize.ts
@@ -1,4 +1,5 @@
 import {
+  availableAmount,
   bjornifyFamiliar,
   canEquip,
   enthroneFamiliar,
@@ -134,7 +135,7 @@ function checkCache(
  */
 function applyCached(entry: CacheEntry): void {
   for (const [slot, item] of entry.equipment) {
-    if (equippedItem(slot) !== item) {
+    if (equippedItem(slot) !== item && availableAmount(item) > 0) {
       equip(slot, item);
     }
   }

--- a/src/maximize.ts
+++ b/src/maximize.ts
@@ -10,7 +10,7 @@ import {
   myEnthronedFamiliar,
   myFamiliar,
 } from "kolmafia";
-import { $familiar, $item, $slots, $stats } from "./template-string";
+import { $familiar, $item, $slot, $slots, $stats } from "./template-string";
 import logger from "./logger";
 
 export type MaximizeOptions = {
@@ -194,6 +194,10 @@ function saveCached(cacheKey: string): void {
 
   for (const slot of cachedSlots) {
     equipment.set(slot, equippedItem(slot));
+  }
+
+  if (equippedAmount($item`card sleeve`) > 0) {
+    equipment.set($slot`card-sleeve`, equippedItem($slot`card-sleeve`));
   }
 
   if (equippedAmount($item`Crown of Thrones`) > 0) {

--- a/src/maximize.ts
+++ b/src/maximize.ts
@@ -245,17 +245,13 @@ export function maximizeCached(
   } = { ...defaultMaximizeOptions, ...options };
 
   // Sort each group in objective to ensure consistent ordering in string
-  const collator = new Intl.Collator(undefined, {
-    numeric: true,
-    sensitivity: "base",
-  });
   const objective = [
-    ...objectives.sort(collator.compare),
-    ...forceEquip.map((item) => `equip ${item}`).sort(collator.compare),
-    ...preventEquip.map((item) => `-equip ${item}`).sort(collator.compare),
+    ...objectives.sort(),
+    ...forceEquip.map((item) => `equip ${item}`).sort(),
+    ...preventEquip.map((item) => `-equip ${item}`).sort(),
     ...Array.from(bonusEquip.entries())
       .map(([item, bonus]) => `${Math.round(bonus * 100) / 100} bonus ${item}`)
-      .sort(collator.compare),
+      .sort(),
   ].join(", ");
 
   const cacheEntry = checkCache(

--- a/src/maximize.ts
+++ b/src/maximize.ts
@@ -1,4 +1,5 @@
 import {
+  bjornifyFamiliar,
   canEquip,
   enthroneFamiliar,
   equip,
@@ -141,7 +142,7 @@ function applyCached(entry: CacheEntry): void {
   }
 
   if (equippedAmount($item`Buddy Bjorn`) > 0) {
-    enthroneFamiliar(entry.rider.get($item`Buddy Bjorn`) || $familiar`none`);
+    bjornifyFamiliar(entry.rider.get($item`Buddy Bjorn`) || $familiar`none`);
   }
 }
 


### PR DESCRIPTION
- Keep track of all previous maximize requests and the resulting equipment
- If a previous cache entry is found, simply re-equip those items in the correct slot. If the equipment fails to be put in the correct slot, fallback and maximize again
- Persist setting to optionally invalidate cache if familiar changes
- Change updateOnStatThreshold setting to updateOnCanEquipChanged, which compares the total number of uniquely items that could be equipped, which prevents unnecessary maximization if stats change but no new items could be worn. This number is also cached so the item list isn't filtered again if stats are unchanged.
- locale sort the maximize string by group, to ensure consistent ordering within the string
- Round bonus number to two decimal places
- Add proper variables for +slot (only consider this slot) & -slot (ignore this slot entirely), don't cache slots that aren't appropriate if those options are used. -slot isn't passed for buddy-bjorn or crown-of-thrones because ignoring those slots is kind of busted in mafia, however those slots will not be cached.