### PR TITLE
Uncircularize Imports

### DIFF
--- a/src/Path.ts
+++ b/src/Path.ts
@@ -1,4 +1,4 @@
-import { $classes } from ".";
+import { $classes } from "./template-string";
 
 export class Path {
   name: string;

--- a/src/ascend.ts
+++ b/src/ascend.ts
@@ -9,9 +9,11 @@ import {
   visitUrl,
   xpath,
 } from "kolmafia";
-import { $item, $items, $stat, get, have } from ".";
+import { $item, $items, $stat } from "./template-string";
+import { get } from "./property";
 import { Path } from "./Path";
 import { ChateauMantegna } from "./resources";
+import { have } from "./lib";
 
 export enum Lifestyle {
   casual = 1,

--- a/src/combat.ts
+++ b/src/combat.ts
@@ -11,7 +11,7 @@ import {
   visitUrl,
   xpath,
 } from "kolmafia";
-import { $items, $skills } from ".";
+import { $items, $skills } from "./template-string";
 import { get, set } from "./property";
 
 const MACRO_NAME = "Script Autoattack Macro";

--- a/src/resources/2015/ChateauMantegna.ts
+++ b/src/resources/2015/ChateauMantegna.ts
@@ -25,16 +25,15 @@ const nightstands = $items`foreign language tapes, bowl of potpourri, electric m
 
 export function getDesk(): Item {
   return (
-    desks.find((desk) =>
-      Object.getOwnPropertyNames(getChateau()).includes(desk.name)
-    ) || $item`none`
+    desks.find((desk) => Object.keys(getChateau()).includes(desk.name)) ||
+    $item`none`
   );
 }
 
 export function getCeiling(): Item {
   return (
     ceilings.find((ceiling) =>
-      Object.getOwnPropertyNames(getChateau()).includes(ceiling.name)
+      Object.keys(getChateau()).includes(ceiling.name)
     ) || $item`none`
   );
 }
@@ -42,7 +41,7 @@ export function getCeiling(): Item {
 export function getNightstand(): Item {
   return (
     nightstands.find((nightstand) =>
-      Object.getOwnPropertyNames(getChateau()).includes(nightstand.name)
+      Object.keys(getChateau()).includes(nightstand.name)
     ) || $item`none`
   );
 }

--- a/src/resources/2015/ChateauMantegna.ts
+++ b/src/resources/2015/ChateauMantegna.ts
@@ -1,5 +1,5 @@
 import { buy, getChateau, runCombat, visitUrl } from "kolmafia";
-import { $item, $items } from "../..";
+import { $item, $items } from "../../template-string";
 import { get } from "../../property";
 
 export function have(): boolean {


### PR DESCRIPTION
I'm not actually sure if this is where things went awry, but either ascend.ts or ChateauMantegna.ts introduced circular imports with its use of template strings. So let's see if this is any better.