### PR TITLE
chore: `yarn clean` deletes `dist/` dir

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "private": false,
   "scripts": {
     "build": "yarn run tsc",
-    "clean": "rm -f {src,dist}/*.js {src,dist}/*.d.ts {src,dist}/**/*.js {src,dist}/**/*.d.ts",
+    "clean": "rm -rf dist",
     "docs": "yarn run typedoc",
     "format": "yarn run prettier --write src/**/* examples/**/*",
     "lint": "yarn run eslint src --ext .ts",


### PR DESCRIPTION
Let's simplify the `yarn clean` script to recursively delete the `dist` directory. This solves several issues with the previous script:

- The command did not reliably erase files below 2+ levels in `dist/`,  such as `dist/resources/2009/Bandersnatch.js`. This is because the glob `src/**/*.js` does not recurse into subdirectories in Bash by default; you must set `shopt -s globstar` to activate it.
  We could use another tool (such as `rimraf`) that uses its own globbing logic to work around this problem, but simply deleting the `dist` directory is far better.
- The `src/` directory was being cleansed, even though our build script no longer emits `*.js` and `*.d.ts` files in there since 7 months ago. (see #20 and 4b7fc48fbcc11eafd6a87636b91c0e6ae51a8b2a)