### PR TITLE
build: always emit LF line endings

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     ],
     "module": "commonjs",
     "moduleResolution": "node",
+    "newLine": "LF",
     "strict": true,
     "esModuleInterop": true,
     "experimentalDecorators": true,


### PR DESCRIPTION
...even on Windows. This doesn't affect our release pipeline (which runs on Linux machines), but makes development on Windows more reliable.