### PR TITLE
build: use import helpers from tslib

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
   "dependencies": {
     "core-js": "3.15.2",
     "kolmafia": "^1.1.2",
-    "lodash": "^4.17.21"
+    "lodash": "^4.17.21",
+    "tslib": "^2.3.0"
   },
   "husky": {
     "hooks": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "target": "es5",
     "declaration": true,
+    "importHelpers": true,
     "lib": [
       "es2019"
     ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -4098,6 +4098,11 @@ tslib@^1.8.1, tslib@^1.9.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
+tslib@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.0.tgz#803b8cdab3e12ba581a4ca41c8839bbb0dacb09e"
+  integrity sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==
+
 tsutils@^3.17.1:
   version "3.17.1"
   resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.17.1.tgz#ed719917f11ca0dee586272b2ac49e015a2dd759"


### PR DESCRIPTION
Previously, the TypeScript compiler added helper functions (e.g. `__extend()`, `__makeTemplateObject()`, `__values()`) separately to each emitted `.js` file. This caused a non-trivial amount of code duplication when libram was bundled by a downstream project.

For example, see https://github.com/Loathing-Associates-Scripting-Society/garbage-collector/blob/99e5c66fe702290eb6dab8f6d58adf8ae40087d2/scripts/garbage-collector/garbo.js and count the number of `var __makeTemplateObject` statements.


To solve this, this PR enables `compilerOptions.importHelpers`, which makes TypeScript import the helper functions from [tslib](https://github.com/microsoft/tslib). This also adds tslib to our `dependencies` in `package.json` so that downstream projects can pick it up automatically.