### PR TITLE
Fix funksling predicate

### DIFF
--- a/src/combat.ts
+++ b/src/combat.ts
@@ -65,7 +65,7 @@ function itemOrItemsBallsMacroPredicate(
   itemOrItems: ItemOrName | [ItemOrName, ItemOrName]
 ): string {
   if (Array.isArray(itemOrItems)) {
-    return itemOrItems.map(itemOrItemsBallsMacroName).join(" && ");
+    return itemOrItems.map(itemOrItemsBallsMacroPredicate).join(" && ");
   } else {
     return `hascombatitem ${itemOrItems}`;
   }


### PR DESCRIPTION
The funksling predicate is currently resolving to
`item1 && item2` instead of `hascombatitem item1 && hascombatitem item2` because of a typo.