### PR TITLE
Filter out 0 bonus equipment from maximize

### DIFF
--- a/src/maximize.ts
+++ b/src/maximize.ts
@@ -307,6 +307,7 @@ export function maximizeCached(
       .map((slot) => `-${slot}`)
       .sort(),
     ...Array.from(bonusEquip.entries())
+      .filter(([, bonus]) => bonus !== 0)
       .map(([item, bonus]) => `${Math.round(bonus * 100) / 100} bonus ${item}`)
       .sort(),
   ].join(", ");


### PR DESCRIPTION
Anything with 0 bonus doesn't affect the maximize query and just makes the string longer.