### PR TITLE
Minor improvement to Kmail lib

### DIFF
--- a/src/Kmail.ts
+++ b/src/Kmail.ts
@@ -23,7 +23,7 @@ export default class Kmail {
   type: "normal";
   senderId: number;
   senderName: string;
-  message: string;
+  rawMessage: string;
 
   /**
    * Parses a kmail from KoL's native format
@@ -42,7 +42,7 @@ export default class Kmail {
    */
   static inbox(): Kmail[] {
     return (JSON.parse(
-      visitUrl("api.php?what=kmail&for=ASSistant")
+      visitUrl("api.php?what=kmail&for=libram")
     ) as RawKmail[]).map(Kmail.parse);
   }
 
@@ -188,7 +188,7 @@ export default class Kmail {
     this.type = rawKmail.type as Kmail["type"];
     this.senderId = Number(rawKmail.fromid);
     this.senderName = rawKmail.fromname;
-    this.message = rawKmail.message;
+    this.rawMessage = rawKmail.message;
   }
 
   /**
@@ -198,6 +198,14 @@ export default class Kmail {
    */
   delete(): boolean {
     return Kmail.delete([this]) === 1;
+  }
+
+  /**
+   * Message contents without any HTML from items or meat
+   */
+  get message(): string {
+    const match = this.rawMessage.match(/^(.*?)</);
+    return match ? match[1] : this.rawMessage;
   }
 
   /**

--- a/src/Kmail.ts
+++ b/src/Kmail.ts
@@ -18,12 +18,12 @@ type RawKmail = {
 };
 
 export default class Kmail {
-  id: number;
-  date: Date;
-  type: "normal";
-  senderId: number;
-  senderName: string;
-  rawMessage: string;
+  readonly id: number;
+  readonly date: Date;
+  readonly type: "normal";
+  readonly senderId: number;
+  readonly senderName: string;
+  readonly rawMessage: string;
 
   /**
    * Parses a kmail from KoL's native format


### PR DESCRIPTION
Split `message` and `rawMessage` in `Kmail` to capture the text content of a message