### PR TITLE
Redirect to choice.php if necessary

### DIFF
--- a/src/resources/2015/ChateauMantegna.ts
+++ b/src/resources/2015/ChateauMantegna.ts
@@ -1,4 +1,4 @@
-import { buy, getChateau, runCombat, visitUrl } from "kolmafia";
+import { buy, choiceFollowsFight, getChateau, runCombat, visitUrl } from "kolmafia";
 import { $item, $items } from "../../template-string";
 import { get } from "../../property";
 
@@ -14,9 +14,10 @@ export function paintingFought(): boolean {
   return get("_chateauMonsterFought");
 }
 
-export function fightPainting(): string {
+export function fightPainting(): void {
   visitUrl("place.php?whichplace=chateau&action=chateau_painting", false);
-  return runCombat();
+  runCombat();
+  if (choiceFollowsFight()) visitUrl("choice.php");
 }
 
 const desks = $items`fancy stationery set, Swiss piggy bank, continental juice bar`;

--- a/src/resources/2015/ChateauMantegna.ts
+++ b/src/resources/2015/ChateauMantegna.ts
@@ -14,10 +14,11 @@ export function paintingFought(): boolean {
   return get("_chateauMonsterFought");
 }
 
-export function fightPainting(): void {
+export function fightPainting(): string {
   visitUrl("place.php?whichplace=chateau&action=chateau_painting", false);
-  runCombat();
+  const result = runCombat();
   if (choiceFollowsFight()) visitUrl("choice.php");
+  return result;
 }
 
 const desks = $items`fancy stationery set, Swiss piggy bank, continental juice bar`;

--- a/src/resources/2016/Witchess.ts
+++ b/src/resources/2016/Witchess.ts
@@ -22,7 +22,7 @@ export const pieces = Monster.get([
   "Witchess Witch",
   "Witchess Ox",
 ]);
-export function fightPiece(piece: Monster): void {
+export function fightPiece(piece: Monster): string {
   if (!pieces.includes(piece)) throw new Error("That is not a valid piece.");
   if (
     !visitUrl("campground.php?action=witchess").includes(
@@ -44,6 +44,7 @@ export function fightPiece(piece: Monster): void {
   ) {
     throw new Error("Failed to start fight.");
   }
-  runCombat();
+  const result = runCombat();
   if (choiceFollowsFight()) visitUrl("choice.php");
+  return result;
 }

--- a/src/resources/2016/Witchess.ts
+++ b/src/resources/2016/Witchess.ts
@@ -1,4 +1,4 @@
-import { myHash, runChoice, runCombat, toInt, visitUrl } from "kolmafia";
+import { choiceFollowsFight, myHash, runChoice, runCombat, toInt, visitUrl } from "kolmafia";
 import { haveInCampground } from "../../lib";
 import { get } from "../../property";
 import { $item } from "../../template-string";
@@ -22,7 +22,7 @@ export const pieces = Monster.get([
   "Witchess Witch",
   "Witchess Ox",
 ]);
-export function fightPiece(piece: Monster): string {
+export function fightPiece(piece: Monster): void {
   if (!pieces.includes(piece)) throw new Error("That is not a valid piece.");
   if (
     !visitUrl("campground.php?action=witchess").includes(
@@ -44,5 +44,6 @@ export function fightPiece(piece: Monster): string {
   ) {
     throw new Error("Failed to start fight.");
   }
-  return runCombat();
+  runCombat();
+  if (choiceFollowsFight()) visitUrl("choice.php");
 }


### PR DESCRIPTION
To make these combats consistent with adventureMacro, they should redirect to choice.php when a choice follows a fight. Otherwise, if unhandled, then the user script will crash.