### PR TITLE
cut out the buddy-bjorn filter

### DIFF
--- a/src/maximize.ts
+++ b/src/maximize.ts
@@ -408,14 +408,8 @@ export function maximizeCached(
     ...objectives.sort(),
     ...forceEquip.map((item) => `equip ${item}`).sort(),
     ...preventEquip.map((item) => `-equip ${item}`).sort(),
-    ...onlySlot
-      .filter((slot) => !$slots`buddy-bjorn, crown-of-thrones`.includes(slot))
-      .map((slot) => `${slot}`)
-      .sort(),
-    ...preventSlot
-      .filter((slot) => !$slots`buddy-bjorn, crown-of-thrones`.includes(slot))
-      .map((slot) => `-${slot}`)
-      .sort(),
+    ...onlySlot.map((slot) => `${slot}`).sort(),
+    ...preventSlot.map((slot) => `-${slot}`).sort(),
     ...Array.from(bonusEquip.entries())
       .filter(([, bonus]) => bonus !== 0)
       .map(([item, bonus]) => `${Math.round(bonus * 100) / 100} bonus ${item}`)


### PR DESCRIPTION
Mafia _should_ be supporting the buddy-bjorn and crown-of-thrones slots in the maximizer now, so everything should be cool and good