### PR TITLE
Summon librams

### DIFF
--- a/src/resources/2007/CandyHearts.ts
+++ b/src/resources/2007/CandyHearts.ts
@@ -1,11 +1,16 @@
-import { $items, $skill } from "../../template-string";
+import { $item, $skill } from "../../template-string";
 import { have as _have } from "../../lib";
 
 export const summonSkill = $skill`Summon Candy Heart`;
-const libramItems = $items`green candy heart, lavender candy heart, orange candy heart, pink candy heart, white candy heart, yellow candy heart`;
-const libramExpected = new Map<Item, number>(
-  libramItems.map((item) => [item, 1.0 / libramItems.length])
-);
+const libramChance = 1.0 / 6;
+const libramExpected = new Map<Item, number>([
+  [$item`green candy heart`, libramChance],
+  [$item`lavender candy heart`, libramChance],
+  [$item`orange candy heart`, libramChance],
+  [$item`pink candy heart`, libramChance],
+  [$item`white candy heart`, libramChance],
+  [$item`yellow candy heart`, libramChance],
+]);
 
 /**
  * @returns true if the player can Summon Candy Heart

--- a/src/resources/2007/CandyHearts.ts
+++ b/src/resources/2007/CandyHearts.ts
@@ -3,19 +3,20 @@ import { have as _have } from "../../lib";
 
 export const summonSkill = $skill`Summon Candy Heart`;
 const libramItems = $items`green candy heart, lavender candy heart, orange candy heart, pink candy heart, white candy heart, yellow candy heart`;
+const libramExpected = new Map<Item, number>(
+  libramItems.map((item) => [item, 1.0 / libramItems.length])
+);
 
 /**
- * Returns true if the player can summon candy hearts
+ * @returns true if the player can Summon Candy Heart
  */
 export function have(): boolean {
   return _have(summonSkill);
 }
 
 /**
- * Returns A map containing the chance of an item to be summoned
+ * @returns map containing the chance of an item to be summoned
  */
 export function expected(): Map<Item, number> {
-  const results = new Map<Item, number>();
-  libramItems.forEach((item) => results.set(item, 1.0 / libramItems.length));
-  return results;
+  return libramExpected;
 }

--- a/src/resources/2007/CandyHearts.ts
+++ b/src/resources/2007/CandyHearts.ts
@@ -1,0 +1,21 @@
+import { $items, $skill } from "../../template-string";
+import { have as _have } from "../../lib";
+
+export const summonSkill = $skill`Summon Candy Heart`;
+const libramItems = $items`green candy heart, lavender candy heart, orange candy heart, pink candy heart, white candy heart, yellow candy heart`;
+
+/**
+ * Returns true if the player can summon candy hearts
+ */
+export function have(): boolean {
+  return _have(summonSkill);
+}
+
+/**
+ * Returns A map containing the chance of an item to be summoned
+ */
+export function expected(): Map<Item, number> {
+  const results = new Map<Item, number>();
+  libramItems.forEach((item) => results.set(item, 1.0 / libramItems.length));
+  return results;
+}

--- a/src/resources/2008/DivineFavors.ts
+++ b/src/resources/2008/DivineFavors.ts
@@ -1,10 +1,8 @@
 import { get } from "../../property";
-import { $items, $skill } from "../../template-string";
+import { $item, $skill } from "../../template-string";
 import { have as _have } from "../../lib";
 
 export const summonSkill = $skill`Summon Party Favor`;
-const commonItems = $items`divine blowout, divine can of silly string, divine noisemaker`;
-const rareItems = $items`divine champagne flute, divine champagne popper, divine cracker`;
 
 /**
  * @returns true if the player can Summon Party Favors
@@ -18,12 +16,16 @@ export function have(): boolean {
  */
 export function expected(): Map<Item, number> {
   const rareSummons = get("_favorRareSummons");
-  const rareChance = 1.0 / 2 ** (rareSummons + 1);
+  const totalRareChance = 1.0 / 2 ** (rareSummons + 1);
+  const commonChance = (1.0 - totalRareChance) / 3;
+  const rareChance = totalRareChance / 3;
 
-  const results = new Map<Item, number>();
-  rareItems.forEach((item) => results.set(item, rareChance / rareItems.length));
-  commonItems.forEach((item) =>
-    results.set(item, (1.0 - rareChance) / commonItems.length)
-  );
-  return results;
+  return new Map<Item, number>([
+    [$item`divine blowout`, commonChance],
+    [$item`divine can of silly string`, commonChance],
+    [$item`divine noisemaker`, commonChance],
+    [$item`divine champagne flute`, rareChance],
+    [$item`divine champagne popper`, rareChance],
+    [$item`divine cracker`, rareChance],
+  ]);
 }

--- a/src/resources/2008/DivineFavors.ts
+++ b/src/resources/2008/DivineFavors.ts
@@ -1,0 +1,28 @@
+import { get } from "../../property";
+import { $items, $skill } from "../../template-string";
+import { have as _have } from "../../lib";
+
+export const summonSkill = $skill`Summon Party Favor`;
+const commonItems = $items`divine blowout, divine can of silly string, divine noisemaker`;
+const rareItems = $items`divine champagne flute, divine champagne popper, divine cracker`;
+
+/**
+ * Returns true if the player can summon party favors
+ */
+export function have(): boolean {
+  return _have(summonSkill);
+}
+
+/**
+ * Returns A map containing the chance of an item to be summoned
+ */
+export function expected(): Map<Item, number> {
+  const results = new Map<Item, number>();
+  const rareSummons = get("_favorRareSummons");
+  const rareChance = 1.0 / 2 ** (rareSummons + 1);
+  rareItems.forEach((item) => results.set(item, rareChance / rareItems.length));
+  commonItems.forEach((item) =>
+    results.set(item, (1.0 - rareChance) / commonItems.length)
+  );
+  return results;
+}

--- a/src/resources/2008/DivineFavors.ts
+++ b/src/resources/2008/DivineFavors.ts
@@ -7,19 +7,20 @@ const commonItems = $items`divine blowout, divine can of silly string, divine no
 const rareItems = $items`divine champagne flute, divine champagne popper, divine cracker`;
 
 /**
- * Returns true if the player can summon party favors
+ * @returns true if the player can Summon Party Favors
  */
 export function have(): boolean {
   return _have(summonSkill);
 }
 
 /**
- * Returns A map containing the chance of an item to be summoned
+ * @returns map containing the chance of an item to be summoned
  */
 export function expected(): Map<Item, number> {
-  const results = new Map<Item, number>();
   const rareSummons = get("_favorRareSummons");
   const rareChance = 1.0 / 2 ** (rareSummons + 1);
+
+  const results = new Map<Item, number>();
   rareItems.forEach((item) => results.set(item, rareChance / rareItems.length));
   commonItems.forEach((item) =>
     results.set(item, (1.0 - rareChance) / commonItems.length)

--- a/src/resources/2009/LoveSongs.ts
+++ b/src/resources/2009/LoveSongs.ts
@@ -3,19 +3,20 @@ import { have as _have } from "../../lib";
 
 export const summonSkill = $skill`Summon Love Song`;
 const libramItems = $items`love song of disturbing obsession, love song of icy revenge, love song of naughty innuendo, love song of smoldering passion, love song of sugary cuteness, love song of vague ambiguity`;
+const libramExpected = new Map<Item, number>(
+  libramItems.map((item) => [item, 1.0 / libramItems.length])
+);
 
 /**
- * Returns true if the player can summon love song
+ * @returns true if the player can Summon Love Song
  */
 export function have(): boolean {
   return _have(summonSkill);
 }
 
 /**
- * Returns A map containing the chance of an item to be summoned
+ * @returns map containing the chance of an item to be summoned
  */
 export function expected(): Map<Item, number> {
-  const results = new Map<Item, number>();
-  libramItems.forEach((item) => results.set(item, 1.0 / libramItems.length));
-  return results;
+  return libramExpected;
 }

--- a/src/resources/2009/LoveSongs.ts
+++ b/src/resources/2009/LoveSongs.ts
@@ -1,0 +1,21 @@
+import { $items, $skill } from "../../template-string";
+import { have as _have } from "../../lib";
+
+export const summonSkill = $skill`Summon Love Song`;
+const libramItems = $items`love song of disturbing obsession, love song of icy revenge, love song of naughty innuendo, love song of smoldering passion, love song of sugary cuteness, love song of vague ambiguity`;
+
+/**
+ * Returns true if the player can summon love song
+ */
+export function have(): boolean {
+  return _have(summonSkill);
+}
+
+/**
+ * Returns A map containing the chance of an item to be summoned
+ */
+export function expected(): Map<Item, number> {
+  const results = new Map<Item, number>();
+  libramItems.forEach((item) => results.set(item, 1.0 / libramItems.length));
+  return results;
+}

--- a/src/resources/2009/LoveSongs.ts
+++ b/src/resources/2009/LoveSongs.ts
@@ -1,11 +1,16 @@
-import { $items, $skill } from "../../template-string";
+import { $item, $skill } from "../../template-string";
 import { have as _have } from "../../lib";
 
 export const summonSkill = $skill`Summon Love Song`;
-const libramItems = $items`love song of disturbing obsession, love song of icy revenge, love song of naughty innuendo, love song of smoldering passion, love song of sugary cuteness, love song of vague ambiguity`;
-const libramExpected = new Map<Item, number>(
-  libramItems.map((item) => [item, 1.0 / libramItems.length])
-);
+const libramChance = 1.0 / 6;
+const libramExpected = new Map<Item, number>([
+  [$item`love song of disturbing obsession`, libramChance],
+  [$item`love song of icy revenge`, libramChance],
+  [$item`love song of naughty innuendo`, libramChance],
+  [$item`love song of smoldering passion`, libramChance],
+  [$item`love song of sugary cuteness`, libramChance],
+  [$item`love song of vague ambiguity`, libramChance],
+]);
 
 /**
  * @returns true if the player can Summon Love Song

--- a/src/resources/2010/Brickos.ts
+++ b/src/resources/2010/Brickos.ts
@@ -1,0 +1,26 @@
+import { get } from "../../property";
+import { $item, $skill } from "../../template-string";
+import { have as _have } from "../../lib";
+
+export const summonSkill = $skill`Summon BRICKOs`;
+const brickoItem = $item`BRICKO brick`;
+const brickoEyeItem = $item`BRICKO eye brick`;
+
+/**
+ * Returns true if the player can summon candy hearts
+ */
+export function have(): boolean {
+  return _have(summonSkill);
+}
+
+/**
+ * Returns A map containing the chance of an item to be summoned
+ */
+export function expected(): Map<Item, number> {
+  const results = new Map<Item, number>();
+  const eyeSummons = get("_brickoEyeSummons");
+  const eyeChance = eyeSummons < 3 ? (eyeSummons === 0 ? 0.5 : 1.0 / 3.0) : 0.0;
+  results.set(brickoEyeItem, eyeChance);
+  results.set(brickoItem, 3.0 - eyeChance);
+  return results;
+}

--- a/src/resources/2010/Brickos.ts
+++ b/src/resources/2010/Brickos.ts
@@ -3,24 +3,22 @@ import { $item, $skill } from "../../template-string";
 import { have as _have } from "../../lib";
 
 export const summonSkill = $skill`Summon BRICKOs`;
-const brickoItem = $item`BRICKO brick`;
-const brickoEyeItem = $item`BRICKO eye brick`;
 
 /**
- * Returns true if the player can summon candy hearts
+ * @returns true if the player can Summon BRICKOs
  */
 export function have(): boolean {
   return _have(summonSkill);
 }
 
 /**
- * Returns A map containing the chance of an item to be summoned
+ * @returns map containing the chance of an item to be summoned
  */
 export function expected(): Map<Item, number> {
-  const results = new Map<Item, number>();
   const eyeSummons = get("_brickoEyeSummons");
-  const eyeChance = eyeSummons < 3 ? (eyeSummons === 0 ? 0.5 : 1.0 / 3.0) : 0.0;
-  results.set(brickoEyeItem, eyeChance);
-  results.set(brickoItem, 3.0 - eyeChance);
-  return results;
+  const eyeChance = eyeSummons === 3 ? 0.0 : eyeSummons === 0 ? 0.5 : 1.0 / 3.0;
+  return new Map<Item, number>([
+    [$item`BRICKO eye brick`, eyeChance],
+    [$item`BRICKO brick`, 3.0 - eyeChance],
+  ]);
 }

--- a/src/resources/2011/Gygaxian.ts
+++ b/src/resources/2011/Gygaxian.ts
@@ -3,19 +3,20 @@ import { have as _have } from "../../lib";
 
 export const summonSkill = $skill`Summon Dice`;
 const libramItems = $items`d4, d6, d8, d10, d12, d20`;
+const libramExpected = new Map<Item, number>(
+  libramItems.map((item) => [item, 1.0 / libramItems.length])
+);
 
 /**
- * Returns true if the player can summon dice
+ * @returns true if the player can Summon Dice
  */
 export function have(): boolean {
   return _have(summonSkill);
 }
 
 /**
- * Returns A map containing the chance of an item to be summoned
+ * @returns map containing the chance of an item to be summoned
  */
 export function expected(): Map<Item, number> {
-  const results = new Map<Item, number>();
-  libramItems.forEach((item) => results.set(item, 1.0 / libramItems.length));
-  return results;
+  return libramExpected;
 }

--- a/src/resources/2011/Gygaxian.ts
+++ b/src/resources/2011/Gygaxian.ts
@@ -1,0 +1,21 @@
+import { $items, $skill } from "../../template-string";
+import { have as _have } from "../../lib";
+
+export const summonSkill = $skill`Summon Dice`;
+const libramItems = $items`d4, d6, d8, d10, d12, d20`;
+
+/**
+ * Returns true if the player can summon dice
+ */
+export function have(): boolean {
+  return _have(summonSkill);
+}
+
+/**
+ * Returns A map containing the chance of an item to be summoned
+ */
+export function expected(): Map<Item, number> {
+  const results = new Map<Item, number>();
+  libramItems.forEach((item) => results.set(item, 1.0 / libramItems.length));
+  return results;
+}

--- a/src/resources/2011/Gygaxian.ts
+++ b/src/resources/2011/Gygaxian.ts
@@ -1,11 +1,16 @@
-import { $items, $skill } from "../../template-string";
+import { $item, $skill } from "../../template-string";
 import { have as _have } from "../../lib";
 
 export const summonSkill = $skill`Summon Dice`;
-const libramItems = $items`d4, d6, d8, d10, d12, d20`;
-const libramExpected = new Map<Item, number>(
-  libramItems.map((item) => [item, 1.0 / libramItems.length])
-);
+const libramChance = 1.0 / 6;
+const libramExpected = new Map<Item, number>([
+  [$item`d4`, libramChance],
+  [$item`d6`, libramChance],
+  [$item`d8`, libramChance],
+  [$item`d10`, libramChance],
+  [$item`d12`, libramChance],
+  [$item`d20`, libramChance],
+]);
 
 /**
  * @returns true if the player can Summon Dice

--- a/src/resources/2012/Resolutions.ts
+++ b/src/resources/2012/Resolutions.ts
@@ -1,0 +1,26 @@
+import { $items, $skill } from "../../template-string";
+import { have as _have } from "../../lib";
+
+export const summonSkill = $skill`Summon Resolutions`;
+const commonItems = $items`resolution: be feistier, resolution: be happier, resolution: be sexier, resolution: be smarter, resolution: be stronger, resolution: be wealthier`;
+const rareItems = $items`resolution: be kinder, resolution: be luckier, resolution: be more adventurous`;
+
+/**
+ * Returns true if the player can summon resolutions
+ */
+export function have(): boolean {
+  return _have(summonSkill);
+}
+
+/**
+ * Returns A map containing the chance of an item to be summoned
+ */
+export function expected(): Map<Item, number> {
+  const results = new Map<Item, number>();
+  const rareChance = 0.02;
+  rareItems.forEach((item) => results.set(item, rareChance / rareItems.length));
+  commonItems.forEach((item) =>
+    results.set(item, (1.0 - rareChance) / commonItems.length)
+  );
+  return results;
+}

--- a/src/resources/2012/Resolutions.ts
+++ b/src/resources/2012/Resolutions.ts
@@ -4,23 +4,22 @@ import { have as _have } from "../../lib";
 export const summonSkill = $skill`Summon Resolutions`;
 const commonItems = $items`resolution: be feistier, resolution: be happier, resolution: be sexier, resolution: be smarter, resolution: be stronger, resolution: be wealthier`;
 const rareItems = $items`resolution: be kinder, resolution: be luckier, resolution: be more adventurous`;
+const libramExpected = new Map<Item, number>();
+commonItems.forEach((item) =>
+  libramExpected.set(item, 0.98 / commonItems.length)
+);
+rareItems.forEach((item) => libramExpected.set(item, 0.02 / rareItems.length));
 
 /**
- * Returns true if the player can summon resolutions
+ * @returns true if the player can Summon Resolutions
  */
 export function have(): boolean {
   return _have(summonSkill);
 }
 
 /**
- * Returns A map containing the chance of an item to be summoned
+ * @returns map containing the chance of an item to be summoned
  */
 export function expected(): Map<Item, number> {
-  const results = new Map<Item, number>();
-  const rareChance = 0.02;
-  rareItems.forEach((item) => results.set(item, rareChance / rareItems.length));
-  commonItems.forEach((item) =>
-    results.set(item, (1.0 - rareChance) / commonItems.length)
-  );
-  return results;
+  return libramExpected;
 }

--- a/src/resources/2012/Resolutions.ts
+++ b/src/resources/2012/Resolutions.ts
@@ -1,14 +1,20 @@
-import { $items, $skill } from "../../template-string";
+import { $item, $skill } from "../../template-string";
 import { have as _have } from "../../lib";
 
 export const summonSkill = $skill`Summon Resolutions`;
-const commonItems = $items`resolution: be feistier, resolution: be happier, resolution: be sexier, resolution: be smarter, resolution: be stronger, resolution: be wealthier`;
-const rareItems = $items`resolution: be kinder, resolution: be luckier, resolution: be more adventurous`;
-const libramExpected = new Map<Item, number>();
-commonItems.forEach((item) =>
-  libramExpected.set(item, 0.98 / commonItems.length)
-);
-rareItems.forEach((item) => libramExpected.set(item, 0.02 / rareItems.length));
+const commonChance = 0.98 / 6;
+const rareChance = 0.02 / 3;
+const libramExpected = new Map<Item, number>([
+  [$item`resolution: be feistier`, commonChance],
+  [$item`resolution: be happier`, commonChance],
+  [$item`resolution: be sexier`, commonChance],
+  [$item`resolution: be smarter`, commonChance],
+  [$item`resolution: be stronger`, commonChance],
+  [$item`resolution: be wealthier`, commonChance],
+  [$item`resolution: be kinder`, rareChance],
+  [$item`resolution: be luckier`, rareChance],
+  [$item`resolution: be more adventurous`, rareChance],
+]);
 
 /**
  * @returns true if the player can Summon Resolutions

--- a/src/resources/2013/PulledTaffy.ts
+++ b/src/resources/2013/PulledTaffy.ts
@@ -1,11 +1,8 @@
 import { get } from "../../property";
-import { $item, $items, $skill } from "../../template-string";
+import { $item, $skill } from "../../template-string";
 import { have as _have } from "../../lib";
 
 export const summonSkill = $skill`Summon Taffy`;
-const commonItems = $items`pulled blue taffy, pulled orange taffy, pulled violet taffy, pulled red taffy`;
-const rareItems = $items`pulled indigo taffy, pulled green taffy`;
-const yellowItem = $item`pulled yellow taffy`;
 
 /**
  * @returns true if the player can Summon Taffy
@@ -22,19 +19,20 @@ export function expected(): Map<Item, number> {
   const yellowSummons = get("_taffyYellowSummons");
   const onlyYellow = yellowSummons === 0 && rareSummons === 3;
   const totalRareChance = rareSummons < 4 ? 1.0 / 2 ** (rareSummons + 1) : 0.0;
-  const rareItemChance = onlyYellow
+  const commonChance = (1.0 - totalRareChance) / 4;
+  const rareChance = onlyYellow
     ? 0.0
-    : totalRareChance / (rareItems.length + 1 - get("_taffyYellowSummons"));
+    : totalRareChance / (3 - get("_taffyYellowSummons"));
   const yellowChance =
-    yellowSummons === 1 ? 0.0 : onlyYellow ? totalRareChance : rareItemChance;
+    yellowSummons === 1 ? 0.0 : onlyYellow ? totalRareChance : rareChance;
 
-  const results = new Map<Item, number>();
-  commonItems.forEach((item) =>
-    results.set(item, (1.0 - totalRareChance) / commonItems.length)
-  );
-  rareItems.forEach((item) =>
-    results.set(item, rareItemChance / rareItems.length)
-  );
-  results.set(yellowItem, yellowChance);
-  return results;
+  return new Map<Item, number>([
+    [$item`pulled blue taffy`, commonChance],
+    [$item`pulled orange taffy`, commonChance],
+    [$item`pulled violet taffy`, commonChance],
+    [$item`pulled red taffy`, commonChance],
+    [$item`pulled indigo taffy`, rareChance],
+    [$item`pulled green taffy`, rareChance],
+    [$item`pulled yellow taffy`, yellowChance],
+  ]);
 }

--- a/src/resources/2013/PulledTaffy.ts
+++ b/src/resources/2013/PulledTaffy.ts
@@ -1,0 +1,48 @@
+import { get } from "../../property";
+import { $item, $items, $skill } from "../../template-string";
+import { have as _have } from "../../lib";
+
+export const summonSkill = $skill`Summon Taffy`;
+const commonItems = $items`pulled blue taffy, pulled orange taffy, pulled violet taffy, pulled red taffy`;
+const rareItems = $items`pulled indigo taffy, pulled green taffy`;
+const yellowItem = $item`pulled yellow taffy`;
+
+/**
+ * Returns true if the player can summon taffy
+ */
+export function have(): boolean {
+  return _have(summonSkill);
+}
+
+/**
+ * Returns A map containing the chance of an item to be summoned
+ */
+export function expected(): Map<Item, number> {
+  const results = new Map<Item, number>();
+  const rareSummons = get("_taffyRareSummons");
+  const rareChance = rareSummons < 4 ? 1.0 / 2 ** (rareSummons + 1) : 0.0;
+  const yellowRemaining = get("_taffyYellowSummons") === 0;
+  // Four possible rare summons, one and only one will be pulled yellow taffy
+  if (rareChance > 0.0) {
+    if (yellowRemaining) {
+      if (rareSummons === 3) {
+        results.set(yellowItem, rareChance);
+        rareItems.forEach((item) => results.set(item, 0.0));
+      } else {
+        results.set(yellowItem, rareChance / rareItems.length + 1);
+        rareItems.forEach((item) =>
+          results.set(item, rareChance / rareItems.length + 1)
+        );
+      }
+    } else {
+      results.set(yellowItem, 0.0);
+      rareItems.forEach((item) =>
+        results.set(item, rareChance / rareItems.length)
+      );
+    }
+  }
+  commonItems.forEach((item) =>
+    results.set(item, (1.0 - rareChance) / commonItems.length)
+  );
+  return results;
+}

--- a/src/resources/LibramSummon.ts
+++ b/src/resources/LibramSummon.ts
@@ -34,6 +34,11 @@ import {
   summonSkill as taffySkill,
 } from "./2013/PulledTaffy";
 
+/**
+ *
+ * @param summonSkill The libram summoning skill
+ * @returns map containing the chance of an item to be summoned
+ */
 export function expectedLibramSummon(summonSkill: Skill): Map<Item, number> {
   switch (summonSkill) {
     case candyHeartsSkill:
@@ -54,6 +59,10 @@ export function expectedLibramSummon(summonSkill: Skill): Map<Item, number> {
   return new Map<Item, number>();
 }
 
+/**
+ *
+ * @returns map containing the chance of items to be summoned for each libram summoning skill available
+ */
 export function possibleLibramSummons(): Map<Skill, Map<Item, number>> {
   const results = new Map<Skill, Map<Item, number>>();
   if (candyHeartsHave()) {

--- a/src/resources/LibramSummon.ts
+++ b/src/resources/LibramSummon.ts
@@ -1,0 +1,81 @@
+import {
+  expected as candyHeartsExpected,
+  have as candyHeartsHave,
+  summonSkill as candyHeartsSkill,
+} from "./2007/CandyHearts";
+import {
+  expected as divineFavorsExpected,
+  have as divineFavorsHave,
+  summonSkill as divineFavorsSkill,
+} from "./2008/DivineFavors";
+import {
+  expected as loveSongsExpected,
+  have as loveSongsHave,
+  summonSkill as loveSongsSkill,
+} from "./2009/LoveSongs";
+import {
+  expected as brickosExpected,
+  have as brickosHave,
+  summonSkill as brickosSkill,
+} from "./2010/Brickos";
+import {
+  expected as diceExpected,
+  have as diceHave,
+  summonSkill as diceSkill,
+} from "./2011/Gygaxian";
+import {
+  expected as resolutionsExpected,
+  have as resolutionsHave,
+  summonSkill as resolutionsSkill,
+} from "./2012/Resolutions";
+import {
+  expected as taffyExpected,
+  have as taffyHave,
+  summonSkill as taffySkill,
+} from "./2013/PulledTaffy";
+
+export function expectedLibramSummon(summonSkill: Skill): Map<Item, number> {
+  switch (summonSkill) {
+    case candyHeartsSkill:
+      return candyHeartsExpected();
+    case divineFavorsSkill:
+      return divineFavorsExpected();
+    case loveSongsSkill:
+      return loveSongsExpected();
+    case brickosSkill:
+      return brickosExpected();
+    case diceSkill:
+      return diceExpected();
+    case resolutionsSkill:
+      return resolutionsExpected();
+    case taffySkill:
+      return taffyExpected();
+  }
+  return new Map<Item, number>();
+}
+
+export function possibleLibramSummons(): Map<Skill, Map<Item, number>> {
+  const results = new Map<Skill, Map<Item, number>>();
+  if (candyHeartsHave()) {
+    results.set(candyHeartsSkill, candyHeartsExpected());
+  }
+  if (divineFavorsHave()) {
+    results.set(divineFavorsSkill, divineFavorsExpected());
+  }
+  if (loveSongsHave()) {
+    results.set(loveSongsSkill, loveSongsExpected());
+  }
+  if (brickosHave()) {
+    results.set(brickosSkill, brickosExpected());
+  }
+  if (diceHave()) {
+    results.set(diceSkill, diceExpected());
+  }
+  if (resolutionsHave()) {
+    results.set(resolutionsSkill, resolutionsExpected());
+  }
+  if (taffyHave()) {
+    results.set(taffySkill, taffyExpected());
+  }
+  return results;
+}


### PR DESCRIPTION
Add functions that return a map of possible results when casting a libram summon skill, taking into account the number of rares already summoned if applicable.

The yellow taffy code could probably be made a bit more elegant.