### PR TITLE
create globalMaximizeSettings

### DIFF
--- a/src/maximize.ts
+++ b/src/maximize.ts
@@ -43,7 +43,7 @@ const defaultMaximizeOptions = {
 
 /**
  *
- * @param options Default options for each maximizer run.
+ * @param options Default options for each maximizer run. These are overwritten by any passed maximizer options.
  * @param options.updateOnFamiliarChange Re-run the maximizer if familiar has changed. Default true.
  * @param options.updateOnCanEquipChanged Re-run the maximizer if stats have changed what can be equipped. Default true.
  * @param options.forceEquip Equipment to force-equip ("equip X").
@@ -58,6 +58,10 @@ export function setDefaultMaximizeOptions(
 
 export const globalMaximizeSettings: Partial<MaximizeOptions> = {};
 
+/**
+ * Create global settings for the maximizeCached function, that will be merged into any maximizer settings passed.
+ * @param options Options applied to every maximizer run. These are merged with any existing maximizer options.
+ */
 export function setGlobalMaximizeSettings(
   options: Partial<MaximizeOptions>
 ): void {

--- a/src/maximize.ts
+++ b/src/maximize.ts
@@ -56,6 +56,14 @@ export function setDefaultMaximizeOptions(
   Object.assign(defaultMaximizeOptions, options);
 }
 
+export const globalMaximizeSettings: Partial<MaximizeOptions> = {};
+
+export function setGlobalMaximizeSettings(
+  options: Partial<MaximizeOptions>
+): void {
+  Object.assign(globalMaximizeSettings, options);
+}
+
 // Subset of slots that are valid for caching.
 const cachedSlots = $slots`hat, weapon, off-hand, back, shirt, pants, acc1, acc2, acc3, familiar`;
 
@@ -402,6 +410,16 @@ export function maximizeCached(
     onlySlot: Slot[];
     preventSlot: Slot[];
   } = fullOptions;
+
+  forceEquip.concat(...(globalMaximizeSettings.forceEquip ?? []));
+  preventEquip.concat(...(globalMaximizeSettings.preventEquip ?? []));
+  if (globalMaximizeSettings.bonusEquip) {
+    for (const [key, value] of globalMaximizeSettings.bonusEquip) {
+      bonusEquip.set(key, value);
+    }
+  }
+  onlySlot.concat(...(globalMaximizeSettings.onlySlot ?? []));
+  preventSlot.concat(...(globalMaximizeSettings.preventSlot ?? []));
 
   // Sort each group in objective to ensure consistent ordering in string
   const objective = [


### PR DESCRIPTION
This is a less-dumb but still-not-great solution to the issue described in #147; in this proposal, defaultMaximizeOptions continue to work as before, but a new object, globalMaximizeSettings, get merged into all iterable maximize options passed to the maximizeCached function. 