### PR TITLE
use .filter instead of .find in CombatLoversLocket.findMonster

### DIFF
--- a/src/resources/2022/CombatLoversLocket.ts
+++ b/src/resources/2022/CombatLoversLocket.ts
@@ -87,7 +87,7 @@ export function findMonster(
 
   return (
     availableLocketMonsters()
-      .sort((a, b) => value(b) - value(a))
-      .find(criteria) ?? null
+      .filter(criteria)
+      .sort((a, b) => value(b) - value(a))[0] ?? null
   );
 }


### PR DESCRIPTION
Right now, garbo uses the mallPrice of item drops as part of its `value` function. We want to filter by `criteria` first to radically reduce the number of mallsearches. Doing so makes it unnecessary to use .find, so we juse use [0]