### PR TITLE
restructure CommunityService.ts

### DIFF
--- a/src/challengePaths/2015/CommunityService.ts
+++ b/src/challengePaths/2015/CommunityService.ts
@@ -132,12 +132,16 @@ export default class CommunityService {
    * @param prepare A function that does all necessary preparations for this CS test, including choosing your outfit.
    * @param beCertain Whether we should check council.php instead of mafia to determine whether the test is complete.
    * @param maxTurns We will run the test iff the predicted turns is less than or equal to this parameter.
-   * @returns The output of the prepare function given, or null if the test is already complete.
+   * @returns "completed", "failed", or "already completed".
    */
-  run(prepare: () => void, beCertain = false, maxTurns = Infinity): boolean {
+  run(
+    prepare: () => void,
+    beCertain = false,
+    maxTurns = Infinity
+  ): "completed" | "failed" | "already completed" {
     const finishedFunction = () =>
       beCertain ? this.verifyIsDone() : this.isDone();
-    if (finishedFunction()) return false;
+    if (finishedFunction()) return "already completed";
 
     const startTime = Date.now();
     const startTurns = myTurncount();
@@ -145,7 +149,7 @@ export default class CommunityService {
     try {
       prepare();
     } catch {
-      return false;
+      return "failed";
     }
 
     const prediction = this.predictor();
@@ -160,9 +164,9 @@ export default class CommunityService {
         turnCost: myTurncount() - startTurns,
         seconds: (Date.now() - startTime) / 1000,
       };
-      return true;
+      return "completed";
     }
-    return false;
+    return "failed";
   }
 
   /**

--- a/src/challengePaths/2015/CommunityService.ts
+++ b/src/challengePaths/2015/CommunityService.ts
@@ -135,7 +135,7 @@ export default class CommunityService {
    * @returns "completed", "failed", or "already completed".
    */
   run(
-    prepare: () => void,
+    prepare: () => void | number,
     beCertain = false,
     maxTurns = Infinity
   ): "completed" | "failed" | "already completed" {
@@ -146,8 +146,9 @@ export default class CommunityService {
     const startTime = Date.now();
     const startTurns = myTurncount();
 
+    let additionalTurns: number;
     try {
-      prepare();
+      additionalTurns = prepare() ?? 0;
     } catch {
       return "failed";
     }
@@ -160,7 +161,7 @@ export default class CommunityService {
 
     if (finishedFunction()) {
       CommunityService.log[this.property] = {
-        predictedTurns: prediction,
+        predictedTurns: prediction + additionalTurns,
         turnCost: myTurncount() - startTurns,
         seconds: (Date.now() - startTime) / 1000,
       };

--- a/src/challengePaths/2015/CommunityService.ts
+++ b/src/challengePaths/2015/CommunityService.ts
@@ -122,6 +122,7 @@ export default class CommunityService {
    * @returns Whether mafia believes the test is complete at the end of this function.
    */
   do(): boolean {
+    if (get("csServicesPerformed").trim().length === 0) visitUrl("council.php");
     visitUrl("council.php");
     runChoice(this.choice);
     return this.isDone();

--- a/src/challengePaths/2015/CommunityService.ts
+++ b/src/challengePaths/2015/CommunityService.ts
@@ -35,18 +35,24 @@ import {
 } from "../../template-string";
 import { sum } from "../../utils";
 
-/**
- * A log of the predicted turns, actual turns, and duration of each CS test performed.
- */
-export const log: {
-  [index: string]: {
-    predictedTurns: number;
-    turnCost: number;
-    seconds: number;
-  };
-} = {};
+const thralls = new Map<Stat, Thrall>([
+  [$stat`muscle`, $thrall`Elbow Macaroni`],
+  [$stat`moxie`, $thrall`Penne Dreadful`],
+]);
 
-class Test {
+const statCommunityServicePredictor = (stat: Stat) => {
+  return () =>
+    60 -
+    Math.floor(
+      (1 / 30) *
+        (myBuffedstat(stat) -
+          myBasestat(
+            thralls.get(stat) === myThrall() ? $stat`mysticality` : stat
+          ))
+    );
+};
+
+export default class CommunityService {
   private choice: number;
   private property: string;
   private predictor: () => number;
@@ -59,7 +65,7 @@ class Test {
    * @param predictor A function that returns an estimate for the number of turns that the test will take given your character's current state.
    * @param maximizeRequirements A Requirement object, if applicable, that aligns with the things needed to maximize for this particular test.
    */
-  constructor(
+  private constructor(
     id: number,
     property: string,
     predictor: () => number,
@@ -149,7 +155,7 @@ class Test {
     }
 
     if (finishedFunction()) {
-      log[this.property] = {
+      CommunityService.log[this.property] = {
         predictedTurns: prediction,
         turnCost: myTurncount() - startTurns,
         seconds: (Date.now() - startTime) / 1000,
@@ -168,221 +174,218 @@ class Test {
       `<input type=hidden name=option value=${this.choice}>`
     );
   }
-}
 
-const thralls = new Map<Stat, Thrall>([
-  [$stat`muscle`, $thrall`Elbow Macaroni`],
-  [$stat`moxie`, $thrall`Penne Dreadful`],
-]);
+  /**
+   * A log of the predicted turns, actual turns, and duration of each CS test performed.
+   */
+  static log: {
+    [index: string]: {
+      predictedTurns: number;
+      turnCost: number;
+      seconds: number;
+    };
+  } = {};
 
-const statTestPredictor = (stat: Stat) => {
-  return () =>
-    60 -
-    Math.floor(
-      (1 / 30) *
-        (myBuffedstat(stat) -
-          myBasestat(
-            thralls.get(stat) === myThrall() ? $stat`mysticality` : stat
-          ))
-    );
-};
+  /**
+   * Prints turncount and time details of the test in question.
+   * @param colour The colour (or color) you'd like the log to be printed in.
+   */
+  static printLog(colour = "blue"): void {
+    const logEntries = Object.entries(CommunityService.log);
+    for (const [testName, testEntry] of logEntries) {
+      const { predictedTurns, turnCost, seconds } = testEntry;
 
-export const HP = new Test(
-  1,
-  "Donate Blood",
-  () => 60 - Math.floor((myMaxhp() - myBuffedstat($stat`muscle`) - 3) / 30),
-  new Requirement(["HP"], {})
-);
-
-export const Muscle = new Test(
-  2,
-  "Feed The Children",
-  statTestPredictor($stat`Muscle`),
-  new Requirement(["Muscle"], {})
-);
-
-export const Mysticality = new Test(
-  3,
-  "Build Playground Mazes",
-  statTestPredictor($stat`Mysticality`),
-  new Requirement(["Mysticality"], {})
-);
-
-export const Moxie = new Test(
-  4,
-  "Feed Conspirators",
-  statTestPredictor($stat`Moxie`),
-  new Requirement(["Moxie"], {})
-);
-
-export const FamiliarWeight = new Test(
-  5,
-  "Breed More Collies",
-  () =>
-    60 - Math.floor((familiarWeight(myFamiliar()) + weightAdjustment()) / 5),
-  new Requirement(["Familiar Weight"], {})
-);
-
-export const WeaponDamage = new Test(
-  6,
-  "Reduce Gazelle Population",
-  () => {
-    const weaponPower = getPower(equippedItem($slot`weapon`));
-    const offhandPower =
-      toSlot(equippedItem($slot`off-hand`)) === $slot`weapon`
-        ? getPower(equippedItem($slot`off-hand`))
-        : 0;
-    const familiarPower =
-      toSlot(equippedItem($slot`familiar`)) === $slot`weapon`
-        ? getPower(equippedItem($slot`familiar`))
-        : 0;
-    const songDamage =
-      SongBoom.song() === "These Fists Were Made for Punchin'" ? myLevel() : 0;
-
-    // mafia does not currently count swagger
-    const multiplier = have($effect`Bow-Legged Swagger`) ? 2 : 1;
-
-    // We add 0.001 because the floor function sometimes introduces weird rounding errors
-    return (
-      60 -
-      Math.floor(
-        (multiplier *
-          (getModifier("Weapon Damage") -
-            0.15 * (weaponPower + offhandPower + familiarPower) -
-            songDamage)) /
-          50 +
-          0.001
-      ) -
-      Math.floor(
-        (multiplier * getModifier("Weapon Damage Percent")) / 50 + 0.001
-      )
-    );
-  },
-  new Requirement(["Weapon Damage", "Weapon Damage Percent"], {})
-);
-
-export const SpellDamage = new Test(
-  7,
-  "Make Sausage",
-  () => {
-    const dragonfishDamage =
-      myFamiliar() === $familiar`Magic Dragonfish`
-        ? numericModifier(
-            $familiar`Magic Dragonfish`,
-            "Spell Damage Percent",
-            familiarWeight($familiar`Magic Dragonfish`) + weightAdjustment(),
-            $item`none`
-          )
-        : 0;
-
-    // We add 0.001 because the floor function sometimes introduces weird rounding errors
-    return (
-      60 -
-      Math.floor(getModifier("Spell Damage") / 50 + 0.001) -
-      Math.floor(
-        (getModifier("Spell Damage Percent") - dragonfishDamage) / 50 + 0.001
-      )
-    );
-  },
-  new Requirement(["Spell Damage", "Spell Damage Percent"], {})
-);
-
-export const Noncombat = new Test(
-  8,
-  "Be a Living Statue",
-  () => {
-    const noncombatRate = -1 * getModifier("Combat Rate");
-    const unsoftcappedRate =
-      noncombatRate > 25 ? 25 + (noncombatRate - 25) * 5 : noncombatRate;
-    return 60 - 3 * Math.floor(unsoftcappedRate / 5);
-  },
-  new Requirement(["-combat"], {})
-);
-
-export const BoozeDrop = new Test(
-  9,
-  "Make Margaritas",
-  () => {
-    const mummingCostume = MummingTrunk.currentCostumes().get(myFamiliar());
-    const mummingBuff =
-      mummingCostume && mummingCostume[0] === "Item Drop"
-        ? mummingCostume[1]
-        : 0;
-
-    const familiarItemDrop =
-      numericModifier(
-        myFamiliar(),
-        "Item Drop",
-        familiarWeight(myFamiliar()) + weightAdjustment(),
-        equippedItem($slot`familiar`)
-      ) +
-      mummingBuff -
-      numericModifier(equippedItem($slot`familiar`), "Item Drop");
-
-    const familiarBoozeDrop =
-      numericModifier(
-        myFamiliar(),
-        "Booze Drop",
-        familiarWeight(myFamiliar()) + weightAdjustment(),
-        equippedItem($slot`familiar`)
-      ) - numericModifier(equippedItem($slot`familiar`), "Booze Drop");
-
-    //Champagne doubling does NOT count for CS, so we undouble
-    const multiplier =
-      haveEquipped($item`broken champagne bottle`) &&
-      get("garbageChampagneCharge") > 0
-        ? 0.5
-        : 1;
-
-    // We add 0.001 because the floor function sometimes introduces weird rounding errors
-    return (
-      60 -
-      multiplier *
-        Math.floor((getModifier("Item Drop") - familiarItemDrop) / 30 + 0.001) -
-      Math.floor((getModifier("Booze Drop") - familiarBoozeDrop) / 15 + 0.001)
-    );
-  },
-  new Requirement(["Item Drop", "2 Booze Drop"], {
-    preventEquip: $items`broken champagne bottle`,
-  })
-);
-
-export const HotRes = new Test(
-  10,
-  "Clean Steam Tunnels",
-  () => 60 - getModifier("Hot Resistance"),
-  new Requirement(["Hot Resistance"], {})
-);
-
-export const CoilWire = new Test(11, "Coil Wire", () => 60, null);
-
-/**
- * Prints turncount and time details of the test in question.
- * @param colour The colour (or color) you'd like the log to be printed in.
- */
-export function printLog(colour = "blue"): void {
-  const logEntries = Object.entries(log);
-  for (const [testName, testEntry] of logEntries) {
-    const { predictedTurns, turnCost, seconds } = testEntry;
-
+      print(
+        `We predicted the ${testName} test would take ${predictedTurns} turns, ${
+          predictedTurns === turnCost ? "and" : "but"
+        } it took ${turnCost} turns`,
+        colour
+      );
+      print(`${testName} took ${seconds} seconds`, colour);
+    }
     print(
-      `We predicted the ${testName} test would take ${predictedTurns} turns, ${
-        predictedTurns === turnCost ? "and" : "but"
-      } it took ${turnCost} turns`,
+      `All together, you have spent ${sum(
+        logEntries,
+        ([, testEntry]) => testEntry.seconds
+      )} seconds during this Community Service run`,
       colour
     );
-    print(`${testName} took ${seconds} seconds`, colour);
   }
-  print(
-    `All together, you have spent ${sum(
-      logEntries,
-      ([, testEntry]) => testEntry.seconds
-    )} seconds during this Community Service run`,
-    colour
+  static HP = new CommunityService(
+    1,
+    "Donate Blood",
+    () => 60 - Math.floor((myMaxhp() - myBuffedstat($stat`muscle`) - 3) / 30),
+    new Requirement(["HP"], {})
   );
-}
 
-export const donate = () => {
-  visitUrl("council.php");
-  visitUrl("choice.php?whichchoice=1089&option=30");
-};
+  static Muscle = new CommunityService(
+    2,
+    "Feed The Children",
+    statCommunityServicePredictor($stat`Muscle`),
+    new Requirement(["Muscle"], {})
+  );
+
+  static Mysticality = new CommunityService(
+    3,
+    "Build Playground Mazes",
+    statCommunityServicePredictor($stat`Mysticality`),
+    new Requirement(["Mysticality"], {})
+  );
+
+  static Moxie = new CommunityService(
+    4,
+    "Feed Conspirators",
+    statCommunityServicePredictor($stat`Moxie`),
+    new Requirement(["Moxie"], {})
+  );
+
+  static FamiliarWeight = new CommunityService(
+    5,
+    "Breed More Collies",
+    () =>
+      60 - Math.floor((familiarWeight(myFamiliar()) + weightAdjustment()) / 5),
+    new Requirement(["Familiar Weight"], {})
+  );
+
+  static WeaponDamage = new CommunityService(
+    6,
+    "Reduce Gazelle Population",
+    () => {
+      const weaponPower = getPower(equippedItem($slot`weapon`));
+      const offhandPower =
+        toSlot(equippedItem($slot`off-hand`)) === $slot`weapon`
+          ? getPower(equippedItem($slot`off-hand`))
+          : 0;
+      const familiarPower =
+        toSlot(equippedItem($slot`familiar`)) === $slot`weapon`
+          ? getPower(equippedItem($slot`familiar`))
+          : 0;
+      const songDamage =
+        SongBoom.song() === "These Fists Were Made for Punchin'"
+          ? myLevel()
+          : 0;
+
+      // mafia does not currently count swagger
+      const multiplier = have($effect`Bow-Legged Swagger`) ? 2 : 1;
+
+      // We add 0.001 because the floor function sometimes introduces weird rounding errors
+      return (
+        60 -
+        Math.floor(
+          (multiplier *
+            (getModifier("Weapon Damage") -
+              0.15 * (weaponPower + offhandPower + familiarPower) -
+              songDamage)) /
+            50 +
+            0.001
+        ) -
+        Math.floor(
+          (multiplier * getModifier("Weapon Damage Percent")) / 50 + 0.001
+        )
+      );
+    },
+    new Requirement(["Weapon Damage", "Weapon Damage Percent"], {})
+  );
+
+  static SpellDamage = new CommunityService(
+    7,
+    "Make Sausage",
+    () => {
+      const dragonfishDamage =
+        myFamiliar() === $familiar`Magic Dragonfish`
+          ? numericModifier(
+              $familiar`Magic Dragonfish`,
+              "Spell Damage Percent",
+              familiarWeight($familiar`Magic Dragonfish`) + weightAdjustment(),
+              $item`none`
+            )
+          : 0;
+
+      // We add 0.001 because the floor function sometimes introduces weird rounding errors
+      return (
+        60 -
+        Math.floor(getModifier("Spell Damage") / 50 + 0.001) -
+        Math.floor(
+          (getModifier("Spell Damage Percent") - dragonfishDamage) / 50 + 0.001
+        )
+      );
+    },
+    new Requirement(["Spell Damage", "Spell Damage Percent"], {})
+  );
+
+  static Noncombat = new CommunityService(
+    8,
+    "Be a Living Statue",
+    () => {
+      const noncombatRate = -1 * getModifier("Combat Rate");
+      const unsoftcappedRate =
+        noncombatRate > 25 ? 25 + (noncombatRate - 25) * 5 : noncombatRate;
+      return 60 - 3 * Math.floor(unsoftcappedRate / 5);
+    },
+    new Requirement(["-combat"], {})
+  );
+
+  static BoozeDrop = new CommunityService(
+    9,
+    "Make Margaritas",
+    () => {
+      const mummingCostume = MummingTrunk.currentCostumes().get(myFamiliar());
+      const mummingBuff =
+        mummingCostume && mummingCostume[0] === "Item Drop"
+          ? mummingCostume[1]
+          : 0;
+
+      const familiarItemDrop =
+        numericModifier(
+          myFamiliar(),
+          "Item Drop",
+          familiarWeight(myFamiliar()) + weightAdjustment(),
+          equippedItem($slot`familiar`)
+        ) +
+        mummingBuff -
+        numericModifier(equippedItem($slot`familiar`), "Item Drop");
+
+      const familiarBoozeDrop =
+        numericModifier(
+          myFamiliar(),
+          "Booze Drop",
+          familiarWeight(myFamiliar()) + weightAdjustment(),
+          equippedItem($slot`familiar`)
+        ) - numericModifier(equippedItem($slot`familiar`), "Booze Drop");
+
+      //Champagne doubling does NOT count for CS, so we undouble
+      const multiplier =
+        haveEquipped($item`broken champagne bottle`) &&
+        get("garbageChampagneCharge") > 0
+          ? 0.5
+          : 1;
+
+      // We add 0.001 because the floor function sometimes introduces weird rounding errors
+      return (
+        60 -
+        multiplier *
+          Math.floor(
+            (getModifier("Item Drop") - familiarItemDrop) / 30 + 0.001
+          ) -
+        Math.floor((getModifier("Booze Drop") - familiarBoozeDrop) / 15 + 0.001)
+      );
+    },
+    new Requirement(["Item Drop", "2 Booze Drop"], {
+      preventEquip: $items`broken champagne bottle`,
+    })
+  );
+
+  static HotRes = new CommunityService(
+    10,
+    "Clean Steam Tunnels",
+    () => 60 - getModifier("Hot Resistance"),
+    new Requirement(["Hot Resistance"], {})
+  );
+
+  static CoilWire = new CommunityService(11, "Coil Wire", () => 60, null);
+
+  static donate = () => {
+    visitUrl("council.php");
+    visitUrl("choice.php?whichchoice=1089&option=30");
+  };
+}

--- a/src/challengePaths/2015/CommunityService.ts
+++ b/src/challengePaths/2015/CommunityService.ts
@@ -69,7 +69,7 @@ export default class CommunityService {
     id: number,
     property: string,
     predictor: () => number,
-    maximizeRequirements: Requirement | null = null
+    maximizeRequirements: Requirement
   ) {
     this.choice = id;
     this.property = property;
@@ -216,6 +216,9 @@ export default class CommunityService {
       colour
     );
   }
+
+  // Below, we have the tests themselves.
+
   static HP = new CommunityService(
     1,
     "Donate Blood",
@@ -358,7 +361,7 @@ export default class CommunityService {
           equippedItem($slot`familiar`)
         ) - numericModifier(equippedItem($slot`familiar`), "Booze Drop");
 
-      //Champagne doubling does NOT count for CS, so we undouble
+      // Champagne doubling does NOT count for CS, so we undouble
       const multiplier =
         haveEquipped($item`broken champagne bottle`) &&
         get("garbageChampagneCharge") > 0
@@ -387,7 +390,12 @@ export default class CommunityService {
     new Requirement(["Hot Resistance"], {})
   );
 
-  static CoilWire = new CommunityService(11, "Coil Wire", () => 60, null);
+  static CoilWire = new CommunityService(
+    11,
+    "Coil Wire",
+    () => 60,
+    new Requirement([], {})
+  );
 
   static donate = () => {
     visitUrl("council.php");

--- a/src/challengePaths/2015/CommunityService.ts
+++ b/src/challengePaths/2015/CommunityService.ts
@@ -367,10 +367,10 @@ export default class CommunityService {
       // We add 0.001 because the floor function sometimes introduces weird rounding errors
       return (
         60 -
-        multiplier *
-          Math.floor(
-            (getModifier("Item Drop") - familiarItemDrop) / 30 + 0.001
-          ) -
+        Math.floor(
+          (multiplier * (getModifier("Item Drop") - familiarItemDrop)) / 30 +
+            0.001
+        ) -
         Math.floor((getModifier("Booze Drop") - familiarBoozeDrop) / 15 + 0.001)
       );
     },

--- a/src/challengePaths/2015/CommunityService.ts
+++ b/src/challengePaths/2015/CommunityService.ts
@@ -6,7 +6,6 @@ import {
   myBasestat,
   myBuffedstat,
   myFamiliar,
-  myLevel,
   myMaxhp,
   myThrall,
   myTurncount,
@@ -23,7 +22,7 @@ import { have } from "../../lib";
 import { Requirement } from "../../maximize";
 import { get as getModifier } from "../../modifier";
 import { get } from "../../property";
-import { MummingTrunk, SongBoom } from "../../resources";
+import { MummingTrunk } from "../../resources";
 import {
   $effect,
   $familiar,
@@ -269,10 +268,6 @@ export default class CommunityService {
         toSlot(equippedItem($slot`familiar`)) === $slot`weapon`
           ? getPower(equippedItem($slot`familiar`))
           : 0;
-      const songDamage =
-        SongBoom.song() === "These Fists Were Made for Punchin'"
-          ? myLevel()
-          : 0;
 
       // mafia does not currently count swagger
       const multiplier = have($effect`Bow-Legged Swagger`) ? 2 : 1;
@@ -283,8 +278,7 @@ export default class CommunityService {
         Math.floor(
           (multiplier *
             (getModifier("Weapon Damage") -
-              0.15 * (weaponPower + offhandPower + familiarPower) -
-              songDamage)) /
+              0.15 * (weaponPower + offhandPower + familiarPower))) /
             50 +
             0.001
         ) -

--- a/src/challengePaths/2015/CommunityService.ts
+++ b/src/challengePaths/2015/CommunityService.ts
@@ -129,7 +129,7 @@ export default class CommunityService {
 
   /**
    * Wrapper function that prepares for a test and then completes it, adding time and turn details to the log.
-   * @param prepare A function that does all necessary preparations for this CS test, including choosing your outfit.
+   * @param prepare A function that does all necessary preparations for this CS test, including choosing your outfit. Optionally returns the number of turns you expect to spend preparing for the test.
    * @param beCertain Whether we should check council.php instead of mafia to determine whether the test is complete.
    * @param maxTurns We will run the test iff the predicted turns is less than or equal to this parameter.
    * @returns "completed", "failed", or "already completed".

--- a/src/challengePaths/index.ts
+++ b/src/challengePaths/index.ts
@@ -1,2 +1,2 @@
-import * as CommunityService from "./2015/CommunityService";
+import CommunityService from "./2015/CommunityService";
 export { CommunityService };


### PR DESCRIPTION
This does a bunch of stuff!

- Changes the Test class to the CommunityService class, makes the constructor private, exports the class, and makes the 11 instances statics on the class
- Change the return typing of CommunityService.test.run() to `"failed" | "already completed" | "completed"`, which corresponds to pretty much what you'd expect
- Allows the `prepare` function called in `run()` to optionally return a numeric value representing the expected number of turns spent during the preparation process (the big shout here is Simmer for spell damage)
- Fiddles around a little bit with documentation and syntax