### PR TITLE
use Infinity as a return value instead of null for Counter.get

### DIFF
--- a/src/counter.ts
+++ b/src/counter.ts
@@ -5,13 +5,13 @@ import { cliExecute, getCounter, getCounters } from "kolmafia";
  * @param counter The name of the counter in question
  * @returns null if the counter does not exist; otherwise returns the duration of the counter
  */
-export function get(counter: string): number | null {
+export function get(counter: string): number {
   const value = getCounter(counter);
   //getCounter returns -1 for counters that don't exist, but it also returns -1 for counters whose value is -1
   if (value === -1) {
     //if we have a counter with value -1, we check to see if that counter exists via getCounters()
     //We return null if it doesn't exist
-    return getCounters(counter, -1, -1).trim() === "" ? null : -1;
+    return getCounters(counter, -1, -1).trim() === "" ? Infinity : -1;
   }
   return value;
 }

--- a/src/counter.ts
+++ b/src/counter.ts
@@ -1,9 +1,9 @@
 import { cliExecute, getCounter, getCounters } from "kolmafia";
 
 /**
- * Returns null for counters that do not exist, and otherwise returns the duration of the counter
+ * Returns Infinity for counters that do not exist, and otherwise returns the duration of the counter
  * @param counter The name of the counter in question
- * @returns null if the counter does not exist; otherwise returns the duration of the counter
+ * @returns Infinity if the counter does not exist; otherwise returns the duration of the counter
  */
 export function get(counter: string): number {
   const value = getCounter(counter);
@@ -14,6 +14,17 @@ export function get(counter: string): number {
     return getCounters(counter, -1, -1).trim() === "" ? Infinity : -1;
   }
   return value;
+}
+
+/**
+ * The world is everything that is the case. This determines which counters are the case.
+ * @param counter The name of the counter in question
+ * @returns True for counters which currently exist; false for those which do not
+ */
+export function exists(counter: string): boolean {
+  return (
+    getCounter(counter) !== -1 || getCounters(counter, -1, -1).trim() !== ""
+  );
 }
 
 /**

--- a/src/counter.ts
+++ b/src/counter.ts
@@ -7,10 +7,10 @@ import { cliExecute, getCounter, getCounters } from "kolmafia";
  */
 export function get(counter: string): number {
   const value = getCounter(counter);
-  //getCounter returns -1 for counters that don't exist, but it also returns -1 for counters whose value is -1
+  // getCounter returns -1 for counters that don't exist, but it also returns -1 for counters whose value is -1
   if (value === -1) {
-    //if we have a counter with value -1, we check to see if that counter exists via getCounters()
-    //We return null if it doesn't exist
+    // if we have a counter with value -1, we check to see if that counter exists via getCounters()
+    // We return null if it doesn't exist
     return getCounters(counter, -1, -1).trim() === "" ? Infinity : -1;
   }
   return value;


### PR DESCRIPTION
Rever and I had a conversation about this. My position boils down to the following:
- `null` as a value has a big disadvantage of making the return type always be `number | null`, which means any time you want to use a comparison operator, you need to throw a `??` in there
- `NaN`'s biggest single disadvantage is that `NaN === NaN` is false. This means that it's very difficult to have a script actively identify unset counters (could we do `const x = Counter.get("whatever"); x !== x`?). It also returns false for all other comparison operators, which is probably bad behavior. Its biggest advantage, however, is that it's falsy. But so is 0, and 0 is a pretty important value for counters.
- `Infinity` behaves the way I personally want it to with all comparisons. It says "this counter isn't happening yet", and it also says "this counter won't happen for a very long time", and it doesn't say "this counter is overdue". It also allows us to identify unset counters via `Counter.get("whatever") === Infinity`.

I'm open to debate as to whether the return value for unset counters should be `null`, `Infinity`, or `NaN`. But I'm also confident enough that the best answer is `Infinity` that I'm making this PR.