### PR TITLE
CommunityService.run() maxTurns check should be Math.min instead of max

### DIFF
--- a/src/challengePaths/2015/CommunityService.ts
+++ b/src/challengePaths/2015/CommunityService.ts
@@ -181,7 +181,7 @@ export default class CommunityService {
     const turns = this._actualCost(council);
     if (!turns) return "already completed";
 
-    if (turns > Math.max(maxTurns, myAdventures())) {
+    if (turns > Math.min(maxTurns, myAdventures())) {
       return "failed";
     }
 


### PR DESCRIPTION
The check for maxTurns should be Math.min instead of Math.max.
e.g if i put maxTurns=1 and have 50 advs left, it should return `failed` if the check takes more than min(1,50)=1 turns