### PR TITLE
Revert "remove unsoftcapping code"

### DIFF
--- a/src/challengePaths/2015/CommunityService.ts
+++ b/src/challengePaths/2015/CommunityService.ts
@@ -389,7 +389,9 @@ export default class CommunityService {
     "Be a Living Statue",
     () => {
       const noncombatRate = -1 * getModifier("Combat Rate");
-      return 60 - 3 * Math.floor(noncombatRate / 5);
+      const unsoftcappedRate =
+        noncombatRate > 25 ? 25 + (noncombatRate - 25) * 5 : noncombatRate;
+      return 60 - 3 * Math.floor(unsoftcappedRate / 5);
     },
     new Requirement(["-combat"], {})
   );


### PR DESCRIPTION
Reverts Loathing-Associates-Scripting-Society/libram#281

1. It looks like "Combat Rate" still returns the soft capped version, while "combat rate" does not
2. The latter is probably not intentional