### PR TITLE
Fix mood MP reservation.

### DIFF
--- a/src/mood.ts
+++ b/src/mood.ts
@@ -11,7 +11,6 @@ import {
   haveSkill,
   hpCost,
   Item,
-  itemAmount,
   mallPrice,
   mpCost,
   myHp,
@@ -33,8 +32,8 @@ import { $item, $skill } from "./template-string";
 import { clamp, sum } from "./utils";
 
 export abstract class MpSource {
-  usesRemaining(): number | null {
-    return null;
+  usesRemaining(): number {
+    return 0;
   }
   abstract availableMpMin(): number;
   availableMpMax(): number {
@@ -50,16 +49,16 @@ export class OscusSoda extends MpSource {
     return have($item`Oscus's neverending soda`);
   }
 
-  usesRemaining(): number | null {
+  usesRemaining(): number {
     return get("oscusSodaUsed") ? 0 : 1;
   }
 
   availableMpMin(): number {
-    return this.available() ? 200 : 0;
+    return this.available() && this.usesRemaining() > 0 ? 200 : 0;
   }
 
   availableMpMax(): number {
-    return this.available() ? 300 : 0;
+    return this.available() && this.usesRemaining() > 0 ? 300 : 0;
   }
 
   execute(): void {
@@ -70,19 +69,23 @@ export class OscusSoda extends MpSource {
 export class MagicalSausages extends MpSource {
   static instance = new MagicalSausages();
 
+  available(): boolean {
+    return have($item`Kramco Sausage-o-Matic™`);
+  }
+
   usesRemaining(): number {
-    return have($item`Kramco Sausage-o-Matic™`)
-      ? 23 - get("_sausagesEaten")
+    const maxSausages =
+      availableAmount($item`magical sausage`) +
+      availableAmount($item`magical sausage casing`);
+    return this.available()
+      ? Math.min(maxSausages, 23 - get("_sausagesEaten"))
       : 0;
   }
 
   availableMpMin(): number {
-    const maxSausages = Math.min(
-      this.usesRemaining(),
-      itemAmount($item`magical sausage`) +
-        itemAmount($item`magical sausage casing`)
-    );
-    return Math.min(myMaxmp(), 999) * maxSausages;
+    return this.available()
+      ? Math.min(myMaxmp(), 999) * this.usesRemaining()
+      : 0;
   }
 
   execute(): void {
@@ -90,8 +93,6 @@ export class MagicalSausages extends MpSource {
     if (mpSpaceAvailable < 700) return;
     const maxSausages = Math.min(
       this.usesRemaining(),
-      itemAmount($item`magical sausage`) +
-        itemAmount($item`magical sausage casing`),
       Math.floor((myMaxmp() - myMp()) / Math.min(myMaxmp() - myMp(), 999))
     );
     retrieveItem(maxSausages, $item`magical sausage`);
@@ -163,10 +164,10 @@ class SkillMoodElement extends MoodElement {
         maxCasts = Math.floor(myHp() / hpCost(this.skill));
       } else {
         const cost = mpCost(this.skill);
-        maxCasts = Math.floor(myMp() / cost);
+        maxCasts = Math.floor(Math.min(mood.availableMp(), myMp()) / cost);
         if (maxCasts === 0) {
           mood.moreMp(cost);
-          maxCasts = Math.floor(myMp() / cost);
+          maxCasts = Math.floor(Math.min(mood.availableMp(), myMp()) / cost);
         }
       }
       const casts = clamp(remainingCasts, 0, Math.min(100, maxCasts));
@@ -336,9 +337,9 @@ export class Mood {
   }
 
   moreMp(minimumTarget: number): void {
+    if (myMp() >= minimumTarget) return;
     for (const mpSource of this.options.mpSources) {
-      const usesRemaining = mpSource.usesRemaining();
-      if (usesRemaining !== null && usesRemaining > 0) {
+      if (mpSource.usesRemaining() > 0) {
         mpSource.execute();
         if (myMp() >= minimumTarget) break;
       }
@@ -424,6 +425,7 @@ export class Mood {
       }
       completeSuccess = element.execute(this, elementTurns) && completeSuccess;
     }
+    this.moreMp(this.options.reserveMp);
     return completeSuccess;
   }
 }


### PR DESCRIPTION
In garbo, this was causing use of non-free restores every turn when building up turns of Pasta Eyeball in certain situations.