### PR TITLE
Add canEquip check to mafia middle finger ring

### DIFF
--- a/src/actions/FreeRun.ts
+++ b/src/actions/FreeRun.ts
@@ -1,4 +1,5 @@
 import {
+  canEquip,
   cliExecute,
   myTurncount,
   restoreMp,
@@ -137,6 +138,7 @@ const freeRunSources: ActionSource[] = [
     $item`mafia middle finger ring`,
     () =>
       have($item`mafia middle finger ring`) &&
+      canEquip($item`mafia middle finger ring`) &&
       !get("_mafiaMiddleFingerRingUsed")
         ? 1
         : 0,


### PR DESCRIPTION
It's possible the 45 muscle requirement isn't met, which will cause an error when trying to force equip it.